### PR TITLE
Export Trade data with json and allow importing json file

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Components/ExportFile.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ExportFile.razor
@@ -7,6 +7,7 @@
 @inject YearOptions years
 @inject UkCalculationResultExportService calculationResultExportService
 @inject UkSection104ExportService ukSection104ExportService
+@inject ExportTaxEventService exportTaxEventService
 
 <div class="container bg-dark text-light mb-4">
     <div class="row">
@@ -24,6 +25,16 @@
         </div>
         <div class="col-md-4 mb-2">
             <SfButton @onclick="InvokeExportSection104" CssClass="btn btn-primary w-100">Export Section104</SfButton>
+        </div>
+        <div class="col-md-12 mb-2">
+            <div class="note">
+                <p class="text-info">Note: The export trade button give you a .json file, allowing you to import this file instead of your broker statements in the future.
+                    This can also be used to export your manually entered trade in the "Add Trade" page.
+                </p>
+            </div>
+        </div>
+        <div class="col-md-4 mb-2">
+            <SfButton @onclick="InvokeExportTaxEvents" CssClass="btn btn-primary w-100">Export trade data for future import</SfButton>
         </div>
     </div>
 </div>
@@ -59,5 +70,13 @@
         byte[] file = System.Text.Encoding.UTF8.GetBytes(contents);
         using var streamRef = new DotNetStreamReference(new MemoryStream(file));
         await _downloadFileJsScript!.InvokeVoidAsync("BlazorDownloadFile", "Section104.txt", streamRef);
+    }
+
+    private async Task InvokeExportTaxEvents()
+    {
+        string contents = exportTaxEventService.SerialiseTaxEvents();
+        byte[] file = System.Text.Encoding.UTF8.GetBytes(contents);
+        using var streamRef = new DotNetStreamReference(new MemoryStream(file));
+        await _downloadFileJsScript!.InvokeVoidAsync("BlazorDownloadFile", "data.json", streamRef);
     }
 }

--- a/BlazorApp-Investment Tax Calculator/Model/TaxEventLists.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TaxEventLists.cs
@@ -2,6 +2,7 @@
 using Model.TaxEvents;
 
 namespace Model;
+
 public record TaxEventLists : IDividendLists, ITradeAndCorporateActionList
 {
     public List<Trade> Trades { get; set; } = [];

--- a/BlazorApp-Investment Tax Calculator/Model/TaxEvents/CorporateAction.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TaxEvents/CorporateAction.cs
@@ -1,5 +1,8 @@
-﻿namespace Model.TaxEvents;
+﻿using System.Text.Json.Serialization;
 
+namespace Model.TaxEvents;
+
+[JsonDerivedType(typeof(StockSplit), "stockSplit")]
 public abstract record CorporateAction : TaxEvent
 {
 }

--- a/BlazorApp-Investment Tax Calculator/Model/TaxEvents/Dividend.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TaxEvents/Dividend.cs
@@ -3,13 +3,21 @@
 using Model.Interfaces;
 
 using System.Globalization;
+using System.Text.Json.Serialization;
 
 namespace Model.TaxEvents;
 
 public record Dividend : TaxEvent, ITextFilePrintable
 {
     public required DividendType DividendType { get; set; }
+    [JsonIgnore]
     public RegionInfo CompanyLocation { get; set; } = RegionInfo.CurrentRegion;
+
+    public string CompanyLocationName
+    {
+        get => CompanyLocation.Name;
+        set => CompanyLocation = new RegionInfo(value);
+    }
     public required DescribedMoney Proceed { get; set; }
 
     public string PrintToTextFile()

--- a/BlazorApp-Investment Tax Calculator/Model/TaxEvents/Trade.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TaxEvents/Trade.cs
@@ -4,9 +4,14 @@ using Model.Interfaces;
 
 using System.Collections.Immutable;
 using System.Text;
+using System.Text.Json.Serialization;
+
+using TaxEvents;
 
 namespace Model.TaxEvents;
-
+[JsonDerivedType(typeof(Trade), "trade")]
+[JsonDerivedType(typeof(FxTrade), "fxTrade")]
+[JsonDerivedType(typeof(FutureContractTrade), "futureContractTrade")]
 public record Trade : TaxEvent, ITextFilePrintable
 {
     public virtual AssetCatagoryType AssetType { get; set; } = AssetCatagoryType.STOCK;

--- a/BlazorApp-Investment Tax Calculator/Model/WarppedMoney.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/WarppedMoney.cs
@@ -1,5 +1,7 @@
 ﻿using NMoneys;
 
+using System.Text.Json.Serialization;
+
 namespace Model;
 
 [System.Diagnostics.DebuggerDisplay("{ToString()}")]
@@ -20,6 +22,7 @@ public record WrappedMoney : IComparable<WrappedMoney>, IEquatable<WrappedMoney>
         _nMoney = new Money(amount, BaseCurrency);
     }
 
+    [JsonConstructor]
     public WrappedMoney(decimal amount, string currency)
     {
         _nMoney = new Money(amount, currency);

--- a/BlazorApp-Investment Tax Calculator/Parser/Json/JsonParseController.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/Json/JsonParseController.cs
@@ -1,0 +1,34 @@
+﻿using Model;
+
+using System.Text.Json;
+
+namespace Parser.InteractiveBrokersXml;
+
+public class JsonParseController(AssetTypeToLoadSetting assetTypeToLoadSetting) : ITaxEventFileParser
+{
+    public TaxEventLists ParseFile(string data)
+    {
+        TaxEventLists? result = null;
+        try
+        {
+            result = JsonSerializer.Deserialize<TaxEventLists>(data);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.ToString());
+        }
+        TaxEventLists resultFiltered = new();
+        if (result == null) return resultFiltered;
+        if (assetTypeToLoadSetting.LoadDividends) resultFiltered.Dividends.AddRange(result.Dividends);
+        if (assetTypeToLoadSetting.LoadStocks) resultFiltered.CorporateActions.AddRange(result.CorporateActions);
+        if (assetTypeToLoadSetting.LoadStocks) resultFiltered.Trades.AddRange(result.Trades.Where(trade => trade.AssetType == Enumerations.AssetCatagoryType.STOCK));
+        if (assetTypeToLoadSetting.LoadFutures) resultFiltered.Trades.AddRange(result.Trades.Where(trade => trade.AssetType == Enumerations.AssetCatagoryType.FUTURE));
+        if (assetTypeToLoadSetting.LoadFx) resultFiltered.Trades.AddRange(result.Trades.Where(trade => trade.AssetType == Enumerations.AssetCatagoryType.FX));
+        return resultFiltered;
+    }
+
+    public bool CheckFileValidity(string data, string contentType)
+    {
+        return contentType == "application/json";
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Program.cs
+++ b/BlazorApp-Investment Tax Calculator/Program.cs
@@ -27,6 +27,7 @@ builder.Services.AddSingleton<FileParseController>();
 builder.Services.AddSingleton<YearOptions>();
 builder.Services.AddSingleton<ToastService>();
 builder.Services.AddSingleton<SfGridToolBarHandlingService>();
+builder.Services.AddSingleton<ExportTaxEventService>();
 
 // UK tax specific components - replace if you want to calculate some other countries.
 builder.Services.AddSingleton<UkCalculationResultExportService>();
@@ -37,6 +38,7 @@ builder.Services.AddSingleton<ITradeCalculator, UkFutureTradeCalculator>();
 
 // Register any new broker parsers here in order of priority
 builder.Services.AddSingleton<ITaxEventFileParser, IBParseController>();
+builder.Services.AddSingleton<ITaxEventFileParser, JsonParseController>();
 
 // Models
 TaxEventLists taxEventLists = new();

--- a/BlazorApp-Investment Tax Calculator/Services/ExportTaxEventService.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/ExportTaxEventService.cs
@@ -1,0 +1,14 @@
+﻿using Model;
+
+using System.Text.Json;
+
+namespace Services;
+
+public class ExportTaxEventService(TaxEventLists taxEventLists)
+{
+    private readonly JsonSerializerOptions _options = new() { WriteIndented = true };
+    public string SerialiseTaxEvents()
+    {
+        return JsonSerializer.Serialize(taxEventLists, _options);
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/ViewModel/TradeInputViewModel.cs
+++ b/BlazorApp-Investment Tax Calculator/ViewModel/TradeInputViewModel.cs
@@ -116,7 +116,7 @@ public class TradeInputViewModel
         return errorList;
     }
 
-    public IEnumerable<string> ValidateWarning()
+    public List<string> ValidateWarning()
     {
         List<string> errorList = [];
         if (CommissionAmount < 0) errorList.Add("Commission is negative and means a rebate, please check if this is correct.");


### PR DESCRIPTION
Add a export trade data button in the import/export page, which allow users to get a .json file for the data they have imported.

The .json file can be imported in the future instead of broker statements.