### PR TITLE
Replace Moq with NSubstitute

### DIFF
--- a/UnitTest/Helper/MockTrade.cs
+++ b/UnitTest/Helper/MockTrade.cs
@@ -5,38 +5,38 @@ using Model.Interfaces;
 using Model.TaxEvents;
 using Model.UkTaxModel.Stocks;
 
-using Moq;
+using NSubstitute;
 
 namespace UnitTest.Helper;
 
 public static class MockTrade
 {
-    public static Mock<ITradeTaxCalculation> CreateMockITradeTaxCalculation(decimal quantity, decimal value, TradeType tradeType)
+    public static ITradeTaxCalculation CreateMockITradeTaxCalculation(decimal quantity, decimal value, TradeType tradeType)
     {
-        Mock<ITradeTaxCalculation> mockTrade = new();
-        mockTrade.Setup(f => f.AcquisitionDisposal).Returns(tradeType);
-        mockTrade.Setup(f => f.MatchHistory).Returns([]);
-        mockTrade.Setup(f => f.UnmatchedQty).Returns(quantity);
-        mockTrade.Setup(f => f.UnmatchedCostOrProceed).Returns(new WrappedMoney(value));
-        mockTrade.Setup(f => f.TradeList).Returns([]);
-        mockTrade.Setup(f => f.MatchQty(It.IsAny<decimal>()));
+        ITradeTaxCalculation mockTrade = Substitute.For<ITradeTaxCalculation>();
+        mockTrade.AcquisitionDisposal.Returns(tradeType);
+        mockTrade.AcquisitionDisposal.Returns(tradeType);
+        mockTrade.MatchHistory.Returns([]);
+        mockTrade.UnmatchedQty.Returns(quantity);
+        mockTrade.UnmatchedCostOrProceed.Returns(new WrappedMoney(value));
+        mockTrade.TradeList.Returns([]);
         return mockTrade;
     }
 
-    public static Mock<Trade> CreateMockTrade(string assetName, DateTime dateTime, TradeType tradeType, decimal quantity, decimal baseCurrencyAmount)
+    public static Trade CreateMockTrade(string assetName, DateTime dateTime, TradeType tradeType, decimal quantity, decimal baseCurrencyAmount)
     {
-        var mockTrade = new Mock<Trade>();
-        mockTrade.SetupGet(t => t.AssetName).Returns(assetName);
-        mockTrade.SetupGet(t => t.Date).Returns(dateTime);
-        mockTrade.SetupGet(t => t.AcquisitionDisposal).Returns(tradeType);
-        mockTrade.SetupGet(t => t.Quantity).Returns(quantity);
-        mockTrade.SetupGet(t => t.NetProceed).Returns(new WrappedMoney(baseCurrencyAmount));
+        Trade mockTrade = Substitute.For<Trade>();
+        mockTrade.AssetName.Returns(assetName);
+        mockTrade.Date.Returns(dateTime);
+        mockTrade.AcquisitionDisposal.Returns(tradeType);
+        mockTrade.Quantity.Returns(quantity);
+        mockTrade.NetProceed.Returns(new WrappedMoney(baseCurrencyAmount));
         return mockTrade;
     }
 
     public static TradeTaxCalculation CreateTradeTaxCalculation(string assetName, DateTime dateTime, decimal quantity, decimal value, TradeType tradeType)
     {
-        Mock<Trade> trade = CreateMockTrade(assetName, dateTime, tradeType, quantity, value);
-        return new TradeTaxCalculation(new List<Trade> { trade.Object });
+        Trade trade = CreateMockTrade(assetName, dateTime, tradeType, quantity, value);
+        return new TradeTaxCalculation(new List<Trade> { trade });
     }
 }

--- a/UnitTest/Helper/MockTrade.cs
+++ b/UnitTest/Helper/MockTrade.cs
@@ -15,7 +15,6 @@ public static class MockTrade
     {
         ITradeTaxCalculation mockTrade = Substitute.For<ITradeTaxCalculation>();
         mockTrade.AcquisitionDisposal.Returns(tradeType);
-        mockTrade.AcquisitionDisposal.Returns(tradeType);
         mockTrade.MatchHistory.Returns([]);
         mockTrade.UnmatchedQty.Returns(quantity);
         mockTrade.UnmatchedCostOrProceed.Returns(new WrappedMoney(value));

--- a/UnitTest/Test/Model/DividendCalculationResultTest.cs
+++ b/UnitTest/Test/Model/DividendCalculationResultTest.cs
@@ -1,6 +1,6 @@
 using Model;
 
-using Moq;
+using NSubstitute;
 
 namespace UnitTest.Test.Model;
 
@@ -10,17 +10,17 @@ public class DividendCalculationResultTests
     public void GetTotalDividend_ReturnsCorrectTotalDividend()
     {
         // Arrange
-        Mock<DividendSummary> dividendSummaryMock1 = new();
-        Mock<DividendSummary> dividendSummaryMock2 = new();
-        Mock<DividendSummary> dividendSummaryMock3 = new();
-        dividendSummaryMock1.Setup(i => i.TotalTaxableDividend).Returns(new WrappedMoney(100, "Gbp"));
-        dividendSummaryMock2.Setup(i => i.TotalTaxableDividend).Returns(new WrappedMoney(200, "Gbp"));
-        dividendSummaryMock3.Setup(i => i.TotalTaxableDividend).Returns(new WrappedMoney(300, "Gbp"));
-        dividendSummaryMock1.Setup(i => i.TaxYear).Returns(2021);
-        dividendSummaryMock2.Setup(i => i.TaxYear).Returns(2022);
-        dividendSummaryMock3.Setup(i => i.TaxYear).Returns(2023);
+        DividendSummary dividendSummaryMock1 = Substitute.For<DividendSummary>();
+        DividendSummary dividendSummaryMock2 = Substitute.For<DividendSummary>();
+        DividendSummary dividendSummaryMock3 = Substitute.For<DividendSummary>();
+        dividendSummaryMock1.TotalTaxableDividend.Returns(new WrappedMoney(100, "Gbp"));
+        dividendSummaryMock2.TotalTaxableDividend.Returns(new WrappedMoney(200, "Gbp"));
+        dividendSummaryMock3.TotalTaxableDividend.Returns(new WrappedMoney(300, "Gbp"));
+        dividendSummaryMock1.TaxYear.Returns(2021);
+        dividendSummaryMock2.TaxYear.Returns(2022);
+        dividendSummaryMock3.TaxYear.Returns(2023);
         var result = new DividendCalculationResult();
-        result.SetResult([dividendSummaryMock1.Object, dividendSummaryMock2.Object, dividendSummaryMock3.Object]);
+        result.SetResult([dividendSummaryMock1, dividendSummaryMock2, dividendSummaryMock3]);
         var yearFilter = new List<int> { 2021, 2023 };
 
         // Act
@@ -34,17 +34,17 @@ public class DividendCalculationResultTests
     public void GetForeignTaxPaid_ReturnsCorrectForeignTaxPaid()
     {
         // Arrange
-        Mock<DividendSummary> dividendSummaryMock1 = new();
-        Mock<DividendSummary> dividendSummaryMock2 = new();
-        Mock<DividendSummary> dividendSummaryMock3 = new();
-        dividendSummaryMock1.Setup(i => i.TotalForeignTaxPaid).Returns(new WrappedMoney(30, "Gbp"));
-        dividendSummaryMock2.Setup(i => i.TotalForeignTaxPaid).Returns(new WrappedMoney(50, "Gbp"));
-        dividendSummaryMock3.Setup(i => i.TotalForeignTaxPaid).Returns(new WrappedMoney(70, "Gbp"));
-        dividendSummaryMock1.Setup(i => i.TaxYear).Returns(2021);
-        dividendSummaryMock2.Setup(i => i.TaxYear).Returns(2022);
-        dividendSummaryMock3.Setup(i => i.TaxYear).Returns(2023);
+        DividendSummary dividendSummaryMock1 = Substitute.For<DividendSummary>();
+        DividendSummary dividendSummaryMock2 = Substitute.For<DividendSummary>();
+        DividendSummary dividendSummaryMock3 = Substitute.For<DividendSummary>();
+        dividendSummaryMock1.TotalForeignTaxPaid.Returns(new WrappedMoney(30, "Gbp"));
+        dividendSummaryMock2.TotalForeignTaxPaid.Returns(new WrappedMoney(50, "Gbp"));
+        dividendSummaryMock3.TotalForeignTaxPaid.Returns(new WrappedMoney(70, "Gbp"));
+        dividendSummaryMock1.TaxYear.Returns(2021);
+        dividendSummaryMock2.TaxYear.Returns(2022);
+        dividendSummaryMock3.TaxYear.Returns(2023);
         var result = new DividendCalculationResult();
-        result.SetResult([dividendSummaryMock1.Object, dividendSummaryMock2.Object, dividendSummaryMock3.Object]);
+        result.SetResult([dividendSummaryMock1, dividendSummaryMock2, dividendSummaryMock3]);
         var yearFilter = new List<int> { 2022, 2023 };
 
         // Act
@@ -58,17 +58,17 @@ public class DividendCalculationResultTests
     public void TestNoYearSelected()
     {
         // Arrange
-        Mock<DividendSummary> dividendSummaryMock1 = new();
-        Mock<DividendSummary> dividendSummaryMock2 = new();
-        Mock<DividendSummary> dividendSummaryMock3 = new();
-        dividendSummaryMock1.Setup(i => i.TotalForeignTaxPaid).Returns(new WrappedMoney(30, "Gbp"));
-        dividendSummaryMock2.Setup(i => i.TotalForeignTaxPaid).Returns(new WrappedMoney(50, "Gbp"));
-        dividendSummaryMock3.Setup(i => i.TotalForeignTaxPaid).Returns(new WrappedMoney(70, "Gbp"));
-        dividendSummaryMock1.Setup(i => i.TaxYear).Returns(2021);
-        dividendSummaryMock2.Setup(i => i.TaxYear).Returns(2022);
-        dividendSummaryMock3.Setup(i => i.TaxYear).Returns(2023);
+        DividendSummary dividendSummaryMock1 = Substitute.For<DividendSummary>();
+        DividendSummary dividendSummaryMock2 = Substitute.For<DividendSummary>();
+        DividendSummary dividendSummaryMock3 = Substitute.For<DividendSummary>();
+        dividendSummaryMock1.TotalForeignTaxPaid.Returns(new WrappedMoney(30, "Gbp"));
+        dividendSummaryMock2.TotalForeignTaxPaid.Returns(new WrappedMoney(50, "Gbp"));
+        dividendSummaryMock3.TotalForeignTaxPaid.Returns(new WrappedMoney(70, "Gbp"));
+        dividendSummaryMock1.TaxYear.Returns(2021);
+        dividendSummaryMock2.TaxYear.Returns(2022);
+        dividendSummaryMock3.TaxYear.Returns(2023);
         var result = new DividendCalculationResult();
-        result.SetResult([dividendSummaryMock1.Object, dividendSummaryMock2.Object, dividendSummaryMock3.Object]);
+        result.SetResult([dividendSummaryMock1, dividendSummaryMock2, dividendSummaryMock3]);
         var yearFilter = new List<int>();
 
         // Act

--- a/UnitTest/Test/Model/TaxEventListsTest.cs
+++ b/UnitTest/Test/Model/TaxEventListsTest.cs
@@ -1,7 +1,7 @@
 using Model;
 using Model.TaxEvents;
 
-using Moq;
+using NSubstitute;
 
 namespace UnitTest.Test.Model;
 
@@ -15,16 +15,16 @@ public class TaxEventListsTests
         {
             Trades =
             [
-                new Mock<Trade>().Object,
-                new Mock<Trade>().Object
+                Substitute.For<Trade>(),
+                Substitute.For<Trade>()
             ],
             CorporateActions =
             [
-                new Mock<StockSplit>().Object
+                Substitute.For<StockSplit>()
             ],
             Dividends =
             [
-                new Mock<Dividend>().Object
+                Substitute.For<Dividend>()
             ]
         };
 
@@ -43,18 +43,18 @@ public class TaxEventListsTests
         {
             Trades =
             [
-                new Mock<Trade>().Object,
+                Substitute.For<Trade>(),
             ],
             CorporateActions =
             [
-                new Mock<StockSplit>().Object,
-                new Mock<StockSplit>().Object
+                Substitute.For<StockSplit>(),
+                Substitute.For<StockSplit>()
             ],
             Dividends =
             [
-                new Mock<Dividend>().Object,
-                new Mock<Dividend>().Object,
-                new Mock<Dividend>().Object,
+                Substitute.For<Dividend>(),
+                Substitute.For<Dividend>(),
+                Substitute.For<Dividend>(),
             ]
         };
 
@@ -75,12 +75,12 @@ public class TaxEventListsTests
         // Arrange
         var taxEvents = new List<TaxEvent>
         {
-            new Mock<Trade>().Object,
-            new Mock<StockSplit>().Object,
-            new Mock<StockSplit>().Object,
-            new Mock<Dividend>().Object,
-            new Mock<Dividend>().Object,
-            new Mock<Dividend>().Object,
+            Substitute.For<Trade>(),
+            Substitute.For<StockSplit>(),
+            Substitute.For<StockSplit>(),
+            Substitute.For<Dividend>(),
+            Substitute.For<Dividend>(),
+            Substitute.For<Dividend>(),
         };
 
         var taxEventLists = new TaxEventLists();

--- a/UnitTest/Test/Model/TradeCalculationResultTest.cs
+++ b/UnitTest/Test/Model/TradeCalculationResultTest.cs
@@ -5,7 +5,7 @@ using Enumerations;
 using global::Model;
 using global::Model.Interfaces;
 
-using Moq;
+using NSubstitute;
 
 using System.Collections.Generic;
 
@@ -25,17 +25,17 @@ public class TradeCalculationResultTests
     public void NumberOfDisposals_ReturnsCorrectNumberOfDisposals()
     {
         // Arrange
-        Mock<ITradeTaxCalculation> mock1 = new();
-        mock1.Setup(i => i.Date).Returns(new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Local));
-        mock1.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        Mock<ITradeTaxCalculation> mock2 = new();
-        mock2.Setup(i => i.Date).Returns(new DateTime(2021, 2, 1, 0, 0, 0, DateTimeKind.Local));
-        mock2.Setup(i => i.AcquisitionDisposal).Returns(TradeType.ACQUISITION);
-        Mock<ITradeTaxCalculation> mock3 = new();
-        mock3.Setup(i => i.Date).Returns(new DateTime(2022, 3, 1, 0, 0, 0, DateTimeKind.Local));
-        mock3.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
+        ITradeTaxCalculation mock1 = Substitute.For<ITradeTaxCalculation>();
+        mock1.Date.Returns(new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Local));
+        mock1.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        ITradeTaxCalculation mock2 = Substitute.For<ITradeTaxCalculation>();
+        mock2.Date.Returns(new DateTime(2021, 2, 1, 0, 0, 0, DateTimeKind.Local));
+        mock2.AcquisitionDisposal.Returns(TradeType.ACQUISITION);
+        ITradeTaxCalculation mock3 = Substitute.For<ITradeTaxCalculation>();
+        mock3.Date.Returns(new DateTime(2022, 3, 1, 0, 0, 0, DateTimeKind.Local));
+        mock3.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
         var taxYear = new MockTaxYear();
-        var tradeTaxCalculations = new List<ITradeTaxCalculation> { mock1.Object, mock2.Object, mock3.Object };
+        var tradeTaxCalculations = new List<ITradeTaxCalculation> { mock1, mock2, mock3 };
         var result = new TradeCalculationResult(taxYear);
         result.SetResult(tradeTaxCalculations);
 
@@ -52,24 +52,24 @@ public class TradeCalculationResultTests
     public void DisposalProceeds_ReturnsCorrectDisposalProceeds()
     {
         // Arrange
-        Mock<ITradeTaxCalculation> mock1 = new();
-        mock1.Setup(i => i.Date).Returns(new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Local));
-        mock1.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        mock1.Setup(i => i.TotalProceeds).Returns(new WrappedMoney(100));
-        Mock<ITradeTaxCalculation> mock2 = new();
-        mock2.Setup(i => i.Date).Returns(new DateTime(2021, 2, 1, 0, 0, 0, DateTimeKind.Local));
-        mock2.Setup(i => i.AcquisitionDisposal).Returns(TradeType.ACQUISITION);
-        mock2.Setup(i => i.TotalProceeds).Returns(new WrappedMoney(200));
-        Mock<ITradeTaxCalculation> mock3 = new();
-        mock3.Setup(i => i.Date).Returns(new DateTime(2022, 3, 1, 0, 0, 0, DateTimeKind.Local));
-        mock3.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        mock3.Setup(i => i.TotalProceeds).Returns(new WrappedMoney(300));
-        Mock<ITradeTaxCalculation> mock4 = new();
-        mock4.Setup(i => i.Date).Returns(new DateTime(2023, 3, 1, 0, 0, 0, DateTimeKind.Local));
-        mock4.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        mock4.Setup(i => i.TotalProceeds).Returns(new WrappedMoney(400));
+        ITradeTaxCalculation mock1 = Substitute.For<ITradeTaxCalculation>();
+        mock1.Date.Returns(new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Local));
+        mock1.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        mock1.TotalProceeds.Returns(new WrappedMoney(100));
+        ITradeTaxCalculation mock2 = Substitute.For<ITradeTaxCalculation>();
+        mock2.Date.Returns(new DateTime(2021, 2, 1, 0, 0, 0, DateTimeKind.Local));
+        mock2.AcquisitionDisposal.Returns(TradeType.ACQUISITION);
+        mock2.TotalProceeds.Returns(new WrappedMoney(200));
+        ITradeTaxCalculation mock3 = Substitute.For<ITradeTaxCalculation>();
+        mock3.Date.Returns(new DateTime(2022, 3, 1, 0, 0, 0, DateTimeKind.Local));
+        mock3.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        mock3.TotalProceeds.Returns(new WrappedMoney(300));
+        ITradeTaxCalculation mock4 = Substitute.For<ITradeTaxCalculation>();
+        mock4.Date.Returns(new DateTime(2023, 3, 1, 0, 0, 0, DateTimeKind.Local));
+        mock4.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        mock4.TotalProceeds.Returns(new WrappedMoney(400));
         var taxYear = new MockTaxYear();
-        var tradeTaxCalculations = new List<ITradeTaxCalculation> { mock1.Object, mock2.Object, mock3.Object, mock4.Object };
+        var tradeTaxCalculations = new List<ITradeTaxCalculation> { mock1, mock2, mock3, mock4 };
         var result = new TradeCalculationResult(taxYear);
         result.SetResult(tradeTaxCalculations);
 
@@ -86,24 +86,24 @@ public class TradeCalculationResultTests
     public void AllowableCosts_ReturnsCorrectAllowableCosts()
     {
         // Arrange
-        Mock<ITradeTaxCalculation> mock1 = new();
-        mock1.Setup(i => i.Date).Returns(new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Local));
-        mock1.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        mock1.Setup(i => i.TotalAllowableCost).Returns(new WrappedMoney(100));
-        Mock<ITradeTaxCalculation> mock2 = new();
-        mock2.Setup(i => i.Date).Returns(new DateTime(2021, 2, 1, 0, 0, 0, DateTimeKind.Local));
-        mock2.Setup(i => i.AcquisitionDisposal).Returns(TradeType.ACQUISITION);
-        mock2.Setup(i => i.TotalAllowableCost).Returns(new WrappedMoney(200));
-        Mock<ITradeTaxCalculation> mock3 = new();
-        mock3.Setup(i => i.Date).Returns(new DateTime(2022, 3, 1, 0, 0, 0, DateTimeKind.Local));
-        mock3.Setup(i => i.AcquisitionDisposal).Returns(TradeType.ACQUISITION);
-        mock3.Setup(i => i.TotalAllowableCost).Returns(new WrappedMoney(300));
-        Mock<ITradeTaxCalculation> mock4 = new();
-        mock4.Setup(i => i.Date).Returns(new DateTime(2023, 3, 1, 0, 0, 0, DateTimeKind.Local));
-        mock4.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        mock4.Setup(i => i.TotalAllowableCost).Returns(new WrappedMoney(400));
+        ITradeTaxCalculation mock1 = Substitute.For<ITradeTaxCalculation>();
+        mock1.Date.Returns(new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Local));
+        mock1.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        mock1.TotalAllowableCost.Returns(new WrappedMoney(100));
+        ITradeTaxCalculation mock2 = Substitute.For<ITradeTaxCalculation>();
+        mock2.Date.Returns(new DateTime(2021, 2, 1, 0, 0, 0, DateTimeKind.Local));
+        mock2.AcquisitionDisposal.Returns(TradeType.ACQUISITION);
+        mock2.TotalAllowableCost.Returns(new WrappedMoney(200));
+        ITradeTaxCalculation mock3 = Substitute.For<ITradeTaxCalculation>();
+        mock3.Date.Returns(new DateTime(2022, 3, 1, 0, 0, 0, DateTimeKind.Local));
+        mock3.AcquisitionDisposal.Returns(TradeType.ACQUISITION);
+        mock3.TotalAllowableCost.Returns(new WrappedMoney(300));
+        ITradeTaxCalculation mock4 = Substitute.For<ITradeTaxCalculation>();
+        mock4.Date.Returns(new DateTime(2023, 3, 1, 0, 0, 0, DateTimeKind.Local));
+        mock4.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        mock4.TotalAllowableCost.Returns(new WrappedMoney(400));
         var taxYear = new MockTaxYear();
-        var tradeTaxCalculations = new List<ITradeTaxCalculation> { mock1.Object, mock2.Object, mock3.Object, mock4.Object };
+        var tradeTaxCalculations = new List<ITradeTaxCalculation> { mock1, mock2, mock3, mock4 };
         var result = new TradeCalculationResult(taxYear);
         result.SetResult(tradeTaxCalculations);
 
@@ -120,24 +120,24 @@ public class TradeCalculationResultTests
     public void TotalGainLoss_ReturnsCorrectTotalGainLoss()
     {
         // Arrange
-        Mock<ITradeTaxCalculation> mock1 = new();
-        mock1.Setup(i => i.Date).Returns(new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Local));
-        mock1.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        mock1.Setup(i => i.Gain).Returns(new WrappedMoney(100));
-        Mock<ITradeTaxCalculation> mock2 = new();
-        mock2.Setup(i => i.Date).Returns(new DateTime(2021, 2, 1, 0, 0, 0, DateTimeKind.Local));
-        mock2.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        mock2.Setup(i => i.Gain).Returns(new WrappedMoney(-200));
-        Mock<ITradeTaxCalculation> mock3 = new();
-        mock3.Setup(i => i.Date).Returns(new DateTime(2022, 3, 1, 0, 0, 0, DateTimeKind.Local));
-        mock3.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        mock3.Setup(i => i.Gain).Returns(new WrappedMoney(300));
-        Mock<ITradeTaxCalculation> mock4 = new();
-        mock4.Setup(i => i.Date).Returns(new DateTime(2023, 3, 1, 0, 0, 0, DateTimeKind.Local));
-        mock4.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        mock4.Setup(i => i.Gain).Returns(new WrappedMoney(-400));
+        ITradeTaxCalculation mock1 = Substitute.For<ITradeTaxCalculation>();
+        mock1.Date.Returns(new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Local));
+        mock1.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        mock1.Gain.Returns(new WrappedMoney(100));
+        ITradeTaxCalculation mock2 = Substitute.For<ITradeTaxCalculation>();
+        mock2.Date.Returns(new DateTime(2021, 2, 1, 0, 0, 0, DateTimeKind.Local));
+        mock2.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        mock2.Gain.Returns(new WrappedMoney(-200));
+        ITradeTaxCalculation mock3 = Substitute.For<ITradeTaxCalculation>();
+        mock3.Date.Returns(new DateTime(2022, 3, 1, 0, 0, 0, DateTimeKind.Local));
+        mock3.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        mock3.Gain.Returns(new WrappedMoney(300));
+        ITradeTaxCalculation mock4 = Substitute.For<ITradeTaxCalculation>();
+        mock4.Date.Returns(new DateTime(2023, 3, 1, 0, 0, 0, DateTimeKind.Local));
+        mock4.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        mock4.Gain.Returns(new WrappedMoney(-400));
         var taxYear = new MockTaxYear();
-        var tradeTaxCalculations = new List<ITradeTaxCalculation> { mock1.Object, mock2.Object, mock3.Object, mock4.Object };
+        var tradeTaxCalculations = new List<ITradeTaxCalculation> { mock1, mock2, mock3, mock4 };
         var result = new TradeCalculationResult(taxYear);
         result.SetResult(tradeTaxCalculations);
 

--- a/UnitTest/Test/Model/TradeTaxCalculationTest.cs
+++ b/UnitTest/Test/Model/TradeTaxCalculationTest.cs
@@ -5,7 +5,7 @@ using global::Model;
 using global::Model.TaxEvents;
 using global::Model.UkTaxModel.Stocks;
 
-using Moq;
+using NSubstitute;
 
 using System;
 using System.Collections.Generic;
@@ -20,13 +20,13 @@ public class TradeTaxCalculationTests
     public void TradeTaxCalculation_ThrowsException_WhenTradesHaveDifferentBuySellSides()
     {
         // Arrange
-        Mock<Trade> trade1 = new();
-        Mock<Trade> trade2 = new();
-        Mock<Trade> trade3 = new();
-        trade1.Setup(i => i.AcquisitionDisposal).Returns(TradeType.ACQUISITION);
-        trade2.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        trade3.Setup(i => i.AcquisitionDisposal).Returns(TradeType.ACQUISITION);
-        var trades = new List<Trade> { trade1.Object, trade2.Object, trade3.Object };
+        Trade trade1 = Substitute.For<Trade>();
+        Trade trade2 = Substitute.For<Trade>();
+        Trade trade3 = Substitute.For<Trade>();
+        trade1.AcquisitionDisposal.Returns(TradeType.ACQUISITION);
+        trade2.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        trade3.AcquisitionDisposal.Returns(TradeType.ACQUISITION);
+        var trades = new List<Trade> { trade1, trade2, trade3 };
         // Act & Assert
         Should.Throw<ArgumentException>(() => new TradeTaxCalculation(trades));
     }
@@ -37,16 +37,16 @@ public class TradeTaxCalculationTests
     public void TradeTaxCalculation_SetCorrectBuySellSides(TradeType tradeType)
     {
         // Arrange
-        Mock<Trade> trade1 = new();
-        Mock<Trade> trade2 = new();
-        Mock<Trade> trade3 = new();
-        trade1.Setup(i => i.AcquisitionDisposal).Returns(tradeType);
-        trade2.Setup(i => i.AcquisitionDisposal).Returns(tradeType);
-        trade3.Setup(i => i.AcquisitionDisposal).Returns(tradeType);
-        trade1.Setup(i => i.NetProceed).Returns(new WrappedMoney(100));
-        trade2.Setup(i => i.NetProceed).Returns(new WrappedMoney(100));
-        trade3.Setup(i => i.NetProceed).Returns(new WrappedMoney(100));
-        var trades = new List<Trade> { trade1.Object, trade2.Object, trade3.Object };
+        Trade trade1 = Substitute.For<Trade>();
+        Trade trade2 = Substitute.For<Trade>();
+        Trade trade3 = Substitute.For<Trade>();
+        trade1.AcquisitionDisposal.Returns(tradeType);
+        trade2.AcquisitionDisposal.Returns(tradeType);
+        trade3.AcquisitionDisposal.Returns(tradeType);
+        trade1.NetProceed.Returns(new WrappedMoney(100));
+        trade2.NetProceed.Returns(new WrappedMoney(100));
+        trade3.NetProceed.Returns(new WrappedMoney(100));
+        var trades = new List<Trade> { trade1, trade2, trade3 };
         // Act & Assert
         TradeTaxCalculation calculation = new(trades);
         calculation.AcquisitionDisposal.ShouldBe(tradeType);
@@ -56,13 +56,13 @@ public class TradeTaxCalculationTests
     public void TradeTaxCalculation_CalculatesTotalAllowableCost()
     {
         // Arrange
-        Mock<Trade> trade1 = new();
-        trade1.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        trade1.Setup(i => i.NetProceed).Returns(new WrappedMoney(100));
+        Trade trade1 = Substitute.For<Trade>();
+        trade1.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        trade1.NetProceed.Returns(new WrappedMoney(100));
         var matchHistory = new List<TradeMatch> { TradeCalculationHelper.CreateTradeMatch(TaxMatchType.SECTION_104, 100, new WrappedMoney(100), new WrappedMoney(150)),
                                                   TradeCalculationHelper.CreateTradeMatch(TaxMatchType.SECTION_104, 100, new WrappedMoney(200), new WrappedMoney(250))
                                                 };
-        var calculation = new TradeTaxCalculation(new List<Trade>() { trade1.Object })
+        var calculation = new TradeTaxCalculation(new List<Trade>() { trade1 })
         {
             MatchHistory = matchHistory
         };
@@ -78,13 +78,13 @@ public class TradeTaxCalculationTests
     public void TradeTaxCalculation_CalculatesTotalProceeds()
     {
         // Arrange
-        Mock<Trade> trade1 = new();
-        trade1.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        trade1.Setup(i => i.NetProceed).Returns(new WrappedMoney(100));
+        Trade trade1 = Substitute.For<Trade>();
+        trade1.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        trade1.NetProceed.Returns(new WrappedMoney(100));
         var matchHistory = new List<TradeMatch> { TradeCalculationHelper.CreateTradeMatch(TaxMatchType.SECTION_104, 100, WrappedMoney.GetBaseCurrencyZero(), new WrappedMoney(100)),
                                                   TradeCalculationHelper.CreateTradeMatch(TaxMatchType.SECTION_104, 100, WrappedMoney.GetBaseCurrencyZero(), new WrappedMoney(200))
                                                 };
-        var calculation = new TradeTaxCalculation(new List<Trade>() { trade1.Object })
+        var calculation = new TradeTaxCalculation(new List<Trade>() { trade1 })
         {
             MatchHistory = matchHistory
         };
@@ -100,13 +100,13 @@ public class TradeTaxCalculationTests
     public void TradeTaxCalculation_CalculatesTotalGain()
     {
         // Arrange
-        Mock<Trade> trade1 = new();
-        trade1.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        trade1.Setup(i => i.NetProceed).Returns(new WrappedMoney(100));
+        Trade trade1 = Substitute.For<Trade>();
+        trade1.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        trade1.NetProceed.Returns(new WrappedMoney(100));
         var matchHistory = new List<TradeMatch> { TradeCalculationHelper.CreateTradeMatch(TaxMatchType.SECTION_104, 100, new WrappedMoney(70), new WrappedMoney(100)),
                                                   TradeCalculationHelper.CreateTradeMatch(TaxMatchType.SECTION_104, 100, new WrappedMoney(210), new WrappedMoney(200))
                                                 };
-        var calculation = new TradeTaxCalculation(new List<Trade>() { trade1.Object })
+        var calculation = new TradeTaxCalculation(new List<Trade>() { trade1 })
         {
             MatchHistory = matchHistory
         };
@@ -122,12 +122,12 @@ public class TradeTaxCalculationTests
     public void TestAssetNameInitialised()
     {
         // Arrange
-        Mock<Trade> trade1 = new();
-        trade1.Setup(i => i.AssetName).Returns("IBM");
-        trade1.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        trade1.Setup(i => i.NetProceed).Returns(new WrappedMoney(100));
-        trade1.Setup(i => i.Quantity).Returns(10m);
-        var calculation = new TradeTaxCalculation(new List<Trade>() { trade1.Object });
+        Trade trade1 = Substitute.For<Trade>();
+        trade1.AssetName.Returns("IBM");
+        trade1.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        trade1.NetProceed.Returns(new WrappedMoney(100));
+        trade1.Quantity.Returns(10m);
+        var calculation = new TradeTaxCalculation(new List<Trade>() { trade1 });
         // Assert
         calculation.AssetName.ShouldBe("IBM");
         calculation.CalculationCompleted.ShouldBeFalse();
@@ -137,11 +137,11 @@ public class TradeTaxCalculationTests
     public void TestTradeDateInitialised()
     {
         // Arrange
-        Mock<Trade> trade1 = new();
-        trade1.Setup(i => i.Date).Returns(new DateTime(2023, 1, 1, 12, 34, 56, DateTimeKind.Local));
-        trade1.Setup(i => i.AcquisitionDisposal).Returns(TradeType.DISPOSAL);
-        trade1.Setup(i => i.NetProceed).Returns(new WrappedMoney(100));
-        var calculation = new TradeTaxCalculation(new List<Trade>() { trade1.Object });
+        Trade trade1 = Substitute.For<Trade>();
+        trade1.Date.Returns(new DateTime(2023, 1, 1, 12, 34, 56, DateTimeKind.Local));
+        trade1.AcquisitionDisposal.Returns(TradeType.DISPOSAL);
+        trade1.NetProceed.Returns(new WrappedMoney(100));
+        var calculation = new TradeTaxCalculation(new List<Trade>() { trade1 });
         // Assert
         calculation.Date.ShouldBe(new DateTime(2023, 1, 1, 12, 34, 56, DateTimeKind.Local));
     }
@@ -150,13 +150,13 @@ public class TradeTaxCalculationTests
     public void MatchQty_MatchesAndUpdatesUnmatchedQtyAndUnmatchedNetAmount()
     {
         // Arrange
-        Mock<Trade> trade1 = new();
-        Mock<Trade> trade2 = new();
-        trade1.Setup(i => i.Quantity).Returns(10);
-        trade1.Setup(i => i.NetProceed).Returns(new WrappedMoney(100));
-        trade2.Setup(i => i.Quantity).Returns(20);
-        trade2.Setup(i => i.NetProceed).Returns(new WrappedMoney(200));
-        var trades = new List<Trade> { trade1.Object, trade2.Object };
+        Trade trade1 = Substitute.For<Trade>();
+        Trade trade2 = Substitute.For<Trade>();
+        trade1.Quantity.Returns(10);
+        trade1.NetProceed.Returns(new WrappedMoney(100));
+        trade2.Quantity.Returns(20);
+        trade2.NetProceed.Returns(new WrappedMoney(200));
+        var trades = new List<Trade> { trade1, trade2 };
         var calculation = new TradeTaxCalculation(trades);
 
         // Act
@@ -174,13 +174,13 @@ public class TradeTaxCalculationTests
     public void TestUnmatchedQtyAndValueReturnCorrectResult()
     {
         // Arrange
-        Mock<Trade> trade1 = new();
-        Mock<Trade> trade2 = new();
-        trade1.Setup(i => i.Quantity).Returns(20);
-        trade1.Setup(i => i.NetProceed).Returns(new WrappedMoney(300));
-        trade2.Setup(i => i.Quantity).Returns(60);
-        trade2.Setup(i => i.NetProceed).Returns(new WrappedMoney(500));
-        var trades = new List<Trade> { trade1.Object, trade2.Object };
+        Trade trade1 = Substitute.For<Trade>();
+        Trade trade2 = Substitute.For<Trade>();
+        trade1.Quantity.Returns(20);
+        trade1.NetProceed.Returns(new WrappedMoney(300));
+        trade2.Quantity.Returns(60);
+        trade2.NetProceed.Returns(new WrappedMoney(500));
+        var trades = new List<Trade> { trade1, trade2 };
         var calculation = new TradeTaxCalculation(trades);
         // Act
         decimal unmatchedQty = calculation.UnmatchedQty;

--- a/UnitTest/Test/Model/UkDividendCalculatorTest.cs
+++ b/UnitTest/Test/Model/UkDividendCalculatorTest.cs
@@ -5,7 +5,7 @@ using Model.Interfaces;
 using Model.TaxEvents;
 using Model.UkTaxModel;
 
-using Moq;
+using NSubstitute;
 
 using System.Globalization;
 
@@ -15,9 +15,9 @@ public class UkDividendCalculatorTest
 {
     private static UkDividendCalculator SetUpCalculator(List<Dividend> Dividend)
     {
-        Mock<IDividendLists> mockIDividendLists = new();
-        mockIDividendLists.Setup(f => f.Dividends).Returns(Dividend);
-        return new UkDividendCalculator(mockIDividendLists.Object, new UKTaxYear());
+        IDividendLists mockIDividendLists = Substitute.For<IDividendLists>();
+        mockIDividendLists.Dividends.Returns(Dividend);
+        return new UkDividendCalculator(mockIDividendLists, new UKTaxYear());
     }
 
     [Fact]

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -13,15 +13,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Replace Moq mocks with NSubstitute mocks

Bump versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Replaced Moq with NSubstitute for mocking in multiple test files to streamline testing procedures.
- **Chores**
	- Updated package references in the project, including Microsoft.NET.Test.Sdk, xunit, and xunit.runner.visualstudio, while introducing NSubstitute for enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->