### PR TITLE
Support more date format

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlCashSettlementParser.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlCashSettlementParser.cs
@@ -1,7 +1,6 @@
 ﻿using InvestmentTaxCalculator.Enumerations;
 using InvestmentTaxCalculator.Model.TaxEvents;
 
-using System.Globalization;
 using System.Xml.Linq;
 
 namespace InvestmentTaxCalculator.Parser.InteractiveBrokersXml;
@@ -23,7 +22,7 @@ public static class IBXmlCashSettlementParser
         {
             AssetName = element.GetAttribute("symbol"),
             Description = element.GetAttribute("activityDescription"),
-            Date = DateTime.Parse(element.GetAttribute("date"), CultureInfo.InvariantCulture),
+            Date = XmlParserHelper.ParseDate(element.GetAttribute("date")),
             Amount = element.BuildMoney("amount", "currency"),
             TradeReason = element.GetAttribute("activityDescription") switch
             {

--- a/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlDividendParser.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlDividendParser.cs
@@ -26,7 +26,7 @@ public static class IBXmlDividendParser
             {
                 DividendType = GetDividendType(element),
                 AssetName = element.GetAttribute("symbol"),
-                Date = DateTime.Parse(element.GetAttribute("settleDate"), CultureInfo.InvariantCulture),
+                Date = XmlParserHelper.ParseDate(element.GetAttribute("settleDate")),
                 CompanyLocation = GetCompanyLocation(element),
                 Proceed = element.BuildDescribedMoney("amount", "currency", "fxRateToBase", element.GetAttribute("description"))
             };

--- a/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlFutureTradeParser.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlFutureTradeParser.cs
@@ -2,7 +2,6 @@
 using InvestmentTaxCalculator.Model;
 using InvestmentTaxCalculator.Model.TaxEvents;
 
-using System.Globalization;
 using System.Xml.Linq;
 
 namespace InvestmentTaxCalculator.Parser.InteractiveBrokersXml;
@@ -24,7 +23,7 @@ public static class IBXmlFutureTradeParser
             AcquisitionDisposal = element.GetTradeType(),
             AssetName = element.GetAttribute("symbol"),
             Description = element.GetAttribute("description"),
-            Date = DateTime.Parse(element.GetAttribute("dateTime"), CultureInfo.InvariantCulture),
+            Date = XmlParserHelper.ParseDate(element.GetAttribute("dateTime")),
             Quantity = element.GetQuantity(),
             GrossProceed = new DescribedMoney() { Amount = WrappedMoney.GetBaseCurrencyZero() },
             Expenses = element.BuildExpenses(),

--- a/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlFxParser.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlFxParser.cs
@@ -1,7 +1,6 @@
 ﻿using InvestmentTaxCalculator.Enumerations;
 using InvestmentTaxCalculator.Model;
 using InvestmentTaxCalculator.Model.TaxEvents;
-using InvestmentTaxCalculator.Parser;
 
 using System.Globalization;
 using System.Xml.Linq;
@@ -42,7 +41,7 @@ public class IBXmlFxParser
         decimal amountOfFx = Math.Abs(decimal.Parse(element.GetAttribute("amount")));
         if (amountOfFx == 0) return null; // Nothing to tax if amount is 0.
         string currency = element.GetAttribute("currency");
-        DateTime reportDate = DateTime.Parse(element.GetAttribute("reportDate"), CultureInfo.InvariantCulture);
+        DateTime reportDate = XmlParserHelper.ParseDate(element.GetAttribute("reportDate"));
         DescribedMoney valueInSterlingWrapped = new()
         {
             Amount = new WrappedMoney(amountOfFx, currency),

--- a/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlOptionParser.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlOptionParser.cs
@@ -1,7 +1,6 @@
 ﻿using InvestmentTaxCalculator.Enumerations;
 using InvestmentTaxCalculator.Model.TaxEvents;
 
-using System.Globalization;
 using System.Xml.Linq;
 
 namespace InvestmentTaxCalculator.Parser.InteractiveBrokersXml;
@@ -24,13 +23,13 @@ public static class IBXmlOptionTradeParser
             AcquisitionDisposal = element.GetTradeType(),
             AssetName = element.GetAttribute("symbol"),
             Description = element.GetAttribute("description"),
-            Date = DateTime.Parse(element.GetAttribute("dateTime"), CultureInfo.InvariantCulture),
+            Date = XmlParserHelper.ParseDate(element.GetAttribute("dateTime")),
             Quantity = element.GetQuantity(),
             GrossProceed = element.GetGrossProceed(),
             Expenses = element.BuildExpenses(),
             Underlying = element.GetAttribute("underlyingSymbol"),
             StrikePrice = element.BuildMoney("strike", "currency"),
-            ExpiryDate = DateTime.Parse(element.GetAttribute("expiry"), CultureInfo.InvariantCulture),
+            ExpiryDate = XmlParserHelper.ParseDate(element.GetAttribute("expiry")),
             Multiplier = decimal.Parse(element.GetAttribute("multiplier")),
             PUTCALL = element.GetAttribute("putCall") switch
             {

--- a/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlStockSplitParser.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlStockSplitParser.cs
@@ -1,7 +1,5 @@
 ﻿using InvestmentTaxCalculator.Model.TaxEvents;
-using InvestmentTaxCalculator.Parser;
 
-using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
@@ -24,7 +22,7 @@ public static class IBXmlStockSplitParser
         return new StockSplit
         {
             AssetName = element.GetAttribute("symbol"),
-            Date = DateTime.Parse(element.GetAttribute("dateTime"), CultureInfo.InvariantCulture),
+            Date = XmlParserHelper.ParseDate(element.GetAttribute("dateTime")),
             SplitFrom = ushort.Parse(matchResult.Groups[2].Value),
             SplitTo = ushort.Parse(matchResult.Groups[1].Value),
         };

--- a/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlStockTradeParser.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlStockTradeParser.cs
@@ -1,7 +1,6 @@
 ﻿using InvestmentTaxCalculator.Enumerations;
 using InvestmentTaxCalculator.Model.TaxEvents;
 
-using System.Globalization;
 using System.Xml.Linq;
 
 namespace InvestmentTaxCalculator.Parser.InteractiveBrokersXml;
@@ -22,7 +21,7 @@ public static class IBXmlStockTradeParser
             AcquisitionDisposal = element.GetTradeType(),
             AssetName = element.GetAttribute("symbol"),
             Description = element.GetAttribute("description"),
-            Date = DateTime.Parse(element.GetAttribute("dateTime"), CultureInfo.InvariantCulture),
+            Date = XmlParserHelper.ParseDate(element.GetAttribute("dateTime")),
             Quantity = element.GetQuantity(),
             GrossProceed = element.GetGrossProceed(),
             Expenses = element.BuildExpenses(),

--- a/BlazorApp-Investment Tax Calculator/Parser/XmlParserHelper.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/XmlParserHelper.cs
@@ -1,5 +1,6 @@
 ﻿using InvestmentTaxCalculator.Model;
 
+using System.Globalization;
 using System.Xml.Linq;
 
 namespace InvestmentTaxCalculator.Parser;
@@ -51,5 +52,15 @@ public static class XmlParserHelper
                 $"01-May-21 12:34:56";
             throw new ParseException(exceptionMessage, ex);
         }
+    }
+
+    public static DateTime ParseDate(string dateString)
+    {
+        string[] formats = { "dd-MMM-yyHH:mm:ss", "dd-MMM-yyHHmmss", "dd-MMM-yyyyHH:mm:ss", "dd-MMM-yyyyHHmmss", "dd-MMM-yy", "dd-MMM-yyyy" };
+        if (DateTime.TryParseExact(dateString, formats, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out DateTime date))
+        {
+            return date;
+        }
+        throw new FormatException($"Unable to parse date: {dateString}");
     }
 }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Tests and feedback are welcome, bugs are to be expected.
 ## To use:
 File sample is [here](https://github.com/alexpung/UK-Investment-tax-calculator/blob/master/UnitTest/System%20Test/Interactive%20brokers/TaxExample.xml "here"), you can download it and put it in the web app to see how it works.
 1. You should configure the base currency of your IBKR account to GBP.
-2. Configure flex query from interactive brokers. Following report required. Date format dd-MMM-yy, the date and time separator should be set to a single space.
+2. Configure flex query from interactive brokers. Following report required. Date format dd-MMM-yy, the date and time separator should be set to a single space and time format set to HH:mm:ss.
    1. Cash Transactions: Level of detail: Detail (for dividends)
    2. Corporate actions (for stocks)
    3. Trades: Level of detail: Orders (for stocks)

--- a/UnitTest/System Test/Interactive brokers/InvalidDateExample.xml
+++ b/UnitTest/System Test/Interactive brokers/InvalidDateExample.xml
@@ -1,9 +1,0 @@
-<FlexQueryResponse queryName="Tax" type="AF">
-<FlexStatements count="1">
-<FlexStatement accountId="TestAccount" fromDate="04-Jan-21" toDate="31-Dec-21" period="Last365CalendarDays" whenGenerated="01-Jan-22 00:00:00">
-<Trades>
-<Order currency="USD" fxRateToBase="0.8" assetCategory="STK" symbol="ABC" description="ABC Example Stock" dateTime="01-May-21 123456" quantity="200" proceeds="-2000" taxes="-20" ibCommission="-1.5" ibCommissionCurrency="USD" buySell="BUY" levelOfDetail="ORDER" />
-</Trades>
-</FlexStatement>
-</FlexStatements>
-</FlexQueryResponse>

--- a/UnitTest/Test/Parser/IBXmlDateParseTest.cs
+++ b/UnitTest/Test/Parser/IBXmlDateParseTest.cs
@@ -1,0 +1,63 @@
+using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Parser;
+using InvestmentTaxCalculator.Parser.InteractiveBrokersXml;
+
+using System.Xml.Linq;
+
+namespace UnitTest.Test.Parser;
+
+public class IBXmlDateParseTest
+{
+    [Fact]
+    public void IBXmlFxParser_ParsesValidDateCorrectly()
+    {
+        string xmlContent = @"
+              <FlexStatement>
+                <StmtFunds>
+				  <!-- Foreign currencies -->
+				  <StatementOfFundsLine currency=""DKK"" fxRateToBase=""0.11857"" reportDate=""03-Feb-21"" activityDescription=""RTE(DK0010267129) 
+                   Cash Dividend DKK 2.50 per Share (Ordinary Dividend)"" amount=""4000"" levelOfDetail=""Currency"" />
+			    </StmtFunds>
+                <ConversionRates>
+				  <ConversionRate reportDate=""03-Feb-21"" fromCurrency=""DKK"" toCurrency=""GBP"" rate=""0.11857"" />
+			    </ConversionRates>
+             </FlexStatement>";
+        XElement element = XElement.Parse(xmlContent);
+        IBXmlFxParser parser = new();
+        IList<Trade> result = parser.ParseXml(element);
+
+        result.ShouldNotBeNull();
+        result[0].Date.ShouldBe(new DateTime(2021, 2, 3, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void IBXmlCashSettlementParser_ThrowsParseExceptionForInvalidDate()
+    {
+        string xmlContent = @"
+           <StmtFunds>
+			 <StatementOfFundsLine symbol=""Test"" currency=""DKK"" fxRateToBase=""0.11857"" assetCategory=""OPT"" date=""Invalid Date"" 
+               activityDescription=""Option Cash Settlement for: Exercise"" amount=""4000"" levelOfDetail=""Currency"" />
+		   </StmtFunds>";
+        XElement element = XElement.Parse(xmlContent);
+        Should.Throw<ParseException>(() => IBXmlCashSettlementParser.ParseXml(element));
+    }
+
+    [Theory]
+    [InlineData("01-Feb-2023 12:34:56")]
+    [InlineData("01-Feb-202312:34:56")]
+    [InlineData("01-Feb-2023 123456")]
+    [InlineData("01-Feb-2023123456")]
+    public void TradeMaker_ParsesDateWithDifferentFormat(string dateString)
+    {
+        string xmlContent = @$"
+             <Trades>
+                <Order currency=""USD"" fxRateToBase=""0.8"" assetCategory=""STK"" symbol=""ABC"" 
+                description=""ABC Example Stock"" dateTime=""{dateString}"" quantity=""200"" proceeds=""-2000"" taxes=""-20"" ibCommission=""-1.5"" 
+                ibCommissionCurrency=""USD"" notes=""O"" buySell=""BUY"" levelOfDetail=""ORDER"" />
+             </Trades>";
+        XElement element = XElement.Parse(xmlContent);
+        IList<Trade> result = IBXmlStockTradeParser.ParseXml(element);
+        result.ShouldNotBeNull();
+        result[0].Date.ShouldBe(new DateTime(2023, 2, 1, 12, 34, 56, DateTimeKind.Utc));
+    }
+}


### PR DESCRIPTION
Support date format include "dd-MMM-yyHH:mm:ss", "dd-MMM-yyHHmmss", "dd-MMM-yyyyHH:mm:ss", "dd-MMM-yyyyHHmmss", "dd-MMM-yy", "dd-MMM-yyyy" and extra space allowed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a centralized date parsing utility `XmlParserHelper.ParseDate()` for consistent XML date handling across parsers

- **Improvements**
  - Enhanced date parsing logic in multiple XML parsers to improve reliability and maintainability
  - Updated README configuration instructions for Interactive Brokers flex query setup

- **Testing**
  - Added comprehensive unit tests for XML date parsing functionality
  - Implemented test cases to verify date parsing across different scenarios

- **Cleanup**
  - Removed unused import statements
  - Deleted an example XML file used for testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->