### PR TITLE
Refactor TradeCalculationResult to use AssetCategoryType

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Components/CalculationSummary.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/CalculationSummary.razor
@@ -25,11 +25,11 @@
 
 <div class="mt-4">
     <h3 class="mb-3">Tax Summary:</h3>
-    <p>Number of disposals: @tradeCalculationResult.NumberOfDisposals(years.SelectedOptions)</p>
-    <p>Total Disposal Proceed: @tradeCalculationResult.DisposalProceeds(years.SelectedOptions)</p>
-    <p>Total Allowable Cost: @tradeCalculationResult.AllowableCosts(years.SelectedOptions)</p>
-    <p>Total Gain: @tradeCalculationResult.TotalGain(years.SelectedOptions)</p>
-    <p>Total Loss: @tradeCalculationResult.TotalLoss(years.SelectedOptions)</p>
+    <p>Number of disposals: @tradeCalculationResult.GetNumberOfDisposals(years.SelectedOptions)</p>
+    <p>Total Disposal Proceed: @tradeCalculationResult.GetDisposalProceeds(years.SelectedOptions)</p>
+    <p>Total Allowable Cost: @tradeCalculationResult.GetAllowableCosts(years.SelectedOptions)</p>
+    <p>Total Gain: @tradeCalculationResult.GetTotalGain(years.SelectedOptions)</p>
+    <p>Total Loss: @tradeCalculationResult.GetTotalLoss(years.SelectedOptions)</p>
     <p>Total Dividend: @dividendCalculationResult.GetTotalDividend(years.SelectedOptions)</p>
     <p>Total Foreign Witholding Tax Paid: @dividendCalculationResult.GetForeignTaxPaid(years.SelectedOptions)</p>
 </div>

--- a/BlazorApp-Investment Tax Calculator/Services/PdfExport/PdfExportService.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/PdfExport/PdfExportService.cs
@@ -14,7 +14,7 @@ public class PdfExportService(TaxYearCgtByTypeReportService taxYearCgtByTypeRepo
 {
     public MemoryStream CreatePdf(int year)
     {
-        ISection yearSummarySection = new YearlyTaxSummarySection(taxYearCgtByTypeReportService, taxYearReportService);
+        ISection yearSummarySection = new YearlyTaxSummarySection(tradeCalculationResult, taxYearReportService);
         ISection allTradesListSection = new AllTradesListSection(tradeCalculationResult);
         ISection section104Section = new Section104HistorySection(uKSection104Pools);
         var document = new Document();

--- a/BlazorApp-Investment Tax Calculator/Services/TaxYearCgtByTypeReportService.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/TaxYearCgtByTypeReportService.cs
@@ -31,16 +31,16 @@ public class TaxYearCgtByTypeReportService(TradeCalculationResult tradeCalculati
         return new TaxYearCgtByTypeReport()
         {
             TaxYear = taxYear,
-            ListedSecurityNumberOfDisposals = tradeCalculationResult.NumberOfDisposals([taxYear], AssetGroupType.LISTEDSHARES),
-            ListedSecurityDisposalProceeds = tradeCalculationResult.DisposalProceeds([taxYear], AssetGroupType.LISTEDSHARES).Amount,
-            ListedSecurityAllowableCosts = tradeCalculationResult.AllowableCosts([taxYear], AssetGroupType.LISTEDSHARES).Amount,
-            ListedSecurityGainExcludeLoss = tradeCalculationResult.TotalGain([taxYear], AssetGroupType.LISTEDSHARES).Amount,
-            ListedSecurityLoss = tradeCalculationResult.TotalLoss([taxYear], AssetGroupType.LISTEDSHARES).Amount,
-            OtherAssetsNumberOfDisposals = tradeCalculationResult.NumberOfDisposals([taxYear], AssetGroupType.OTHERASSETS),
-            OtherAssetsDisposalProceeds = tradeCalculationResult.DisposalProceeds([taxYear], AssetGroupType.OTHERASSETS).Amount,
-            OtherAssetsAllowableCosts = tradeCalculationResult.AllowableCosts([taxYear], AssetGroupType.OTHERASSETS).Amount,
-            OtherAssetsGainExcludeLoss = tradeCalculationResult.TotalGain([taxYear], AssetGroupType.OTHERASSETS).Amount,
-            OtherAssetsLoss = tradeCalculationResult.TotalLoss([taxYear], AssetGroupType.OTHERASSETS).Amount
+            ListedSecurityNumberOfDisposals = tradeCalculationResult.GetNumberOfDisposals([taxYear], AssetGroupType.LISTEDSHARES),
+            ListedSecurityDisposalProceeds = tradeCalculationResult.GetDisposalProceeds([taxYear], AssetGroupType.LISTEDSHARES).Amount,
+            ListedSecurityAllowableCosts = tradeCalculationResult.GetAllowableCosts([taxYear], AssetGroupType.LISTEDSHARES).Amount,
+            ListedSecurityGainExcludeLoss = tradeCalculationResult.GetTotalGain([taxYear], AssetGroupType.LISTEDSHARES).Amount,
+            ListedSecurityLoss = tradeCalculationResult.GetTotalLoss([taxYear], AssetGroupType.LISTEDSHARES).Amount,
+            OtherAssetsNumberOfDisposals = tradeCalculationResult.GetNumberOfDisposals([taxYear], AssetGroupType.OTHERASSETS),
+            OtherAssetsDisposalProceeds = tradeCalculationResult.GetDisposalProceeds([taxYear], AssetGroupType.OTHERASSETS).Amount,
+            OtherAssetsAllowableCosts = tradeCalculationResult.GetAllowableCosts([taxYear], AssetGroupType.OTHERASSETS).Amount,
+            OtherAssetsGainExcludeLoss = tradeCalculationResult.GetTotalGain([taxYear], AssetGroupType.OTHERASSETS).Amount,
+            OtherAssetsLoss = tradeCalculationResult.GetTotalLoss([taxYear], AssetGroupType.OTHERASSETS).Amount
         };
     }
 }

--- a/BlazorApp-Investment Tax Calculator/Services/TaxYearReportCgtService.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/TaxYearReportCgtService.cs
@@ -15,8 +15,8 @@ public class TaxYearReportService(TradeCalculationResult tradeCalculationResult,
         decimal capitalLossInPreviousYears = 0m;
         foreach (int taxYear in taxYears)
         {
-            decimal totalGainInYear = tradeCalculationResult.TotalGain([taxYear]).Amount;
-            decimal totalLossInYear = tradeCalculationResult.TotalLoss([taxYear]).Amount; // Is a negative value
+            decimal totalGainInYear = tradeCalculationResult.GetTotalGain([taxYear]).Amount;
+            decimal totalLossInYear = tradeCalculationResult.GetTotalLoss([taxYear]).Amount; // Is a negative value
             decimal netGainInYear = totalGainInYear + totalLossInYear;
             decimal capitalGainAllowance = _ukCapitalGainAllowance.GetTaxAllowance(taxYear);
             decimal lossBroughtForward = 0m;

--- a/UnitTest/Test/Model/TradeCalculationResultTest.cs
+++ b/UnitTest/Test/Model/TradeCalculationResultTest.cs
@@ -48,7 +48,7 @@ public class TradeCalculationResultTests
         var taxYearsFilter = new List<int> { 2021 };
 
         // Act
-        int numberOfDisposals = result.NumberOfDisposals(taxYearsFilter);
+        int numberOfDisposals = result.GetNumberOfDisposals(taxYearsFilter);
 
         // Assert
         numberOfDisposals.ShouldBe(1);
@@ -86,7 +86,7 @@ public class TradeCalculationResultTests
         var taxYearsFilter = new List<int> { 2021, 2023 };
 
         // Act
-        WrappedMoney disposalProceeds = result.DisposalProceeds(taxYearsFilter);
+        WrappedMoney disposalProceeds = result.GetDisposalProceeds(taxYearsFilter);
 
         // Assert
         disposalProceeds.ShouldBe(new WrappedMoney(500));
@@ -124,7 +124,7 @@ public class TradeCalculationResultTests
         var taxYearsFilter = new List<int> { 2021, 2023 };
 
         // Act
-        WrappedMoney allowableCosts = result.AllowableCosts(taxYearsFilter);
+        WrappedMoney allowableCosts = result.GetAllowableCosts(taxYearsFilter);
 
         // Assert
         allowableCosts.ShouldBe(new WrappedMoney(500));
@@ -166,8 +166,8 @@ public class TradeCalculationResultTests
         var taxYearsFilter = new List<int> { 2021, 2023 };
 
         // Act
-        WrappedMoney totalGain = result.TotalGain(taxYearsFilter);
-        WrappedMoney totalLoss = result.TotalLoss(taxYearsFilter);
+        WrappedMoney totalGain = result.GetTotalGain(taxYearsFilter);
+        WrappedMoney totalLoss = result.GetTotalLoss(taxYearsFilter);
 
         // Assert
         totalGain.ShouldBe(new WrappedMoney(100));
@@ -207,16 +207,16 @@ public class TradeCalculationResultTests
         WrappedMoney expectedTotalAllowableCost = new WrappedMoney(150);
         WrappedMoney expectedTotalProceeds = new WrappedMoney(550);
 
-        WrappedMoney totalGain = result.TotalGain(taxYearsFilter, AssetGroupType.ALL);
-        WrappedMoney totalAllowableCost = result.AllowableCosts(taxYearsFilter, AssetGroupType.ALL);
-        WrappedMoney totalProceeds = result.DisposalProceeds(taxYearsFilter, AssetGroupType.ALL);
+        WrappedMoney totalGain = result.GetTotalGain(taxYearsFilter, AssetGroupType.ALL);
+        WrappedMoney totalAllowableCost = result.GetAllowableCosts(taxYearsFilter, AssetGroupType.ALL);
+        WrappedMoney totalProceeds = result.GetDisposalProceeds(taxYearsFilter, AssetGroupType.ALL);
 
         totalGain.ShouldBe(expectedTotalGain);
         totalAllowableCost.ShouldBe(expectedTotalAllowableCost);
         totalProceeds.ShouldBe(expectedTotalProceeds);
-        (result.TotalGain(taxYearsFilter, AssetGroupType.LISTEDSHARES) + result.TotalGain(taxYearsFilter, AssetGroupType.OTHERASSETS)).ShouldBe(expectedTotalGain);
-        (result.AllowableCosts(taxYearsFilter, AssetGroupType.LISTEDSHARES) + result.AllowableCosts(taxYearsFilter, AssetGroupType.OTHERASSETS)).ShouldBe(expectedTotalAllowableCost);
-        (result.DisposalProceeds(taxYearsFilter, AssetGroupType.LISTEDSHARES) + result.DisposalProceeds(taxYearsFilter, AssetGroupType.OTHERASSETS)).ShouldBe(expectedTotalProceeds);
+        (result.GetTotalGain(taxYearsFilter, AssetGroupType.LISTEDSHARES) + result.GetTotalGain(taxYearsFilter, AssetGroupType.OTHERASSETS)).ShouldBe(expectedTotalGain);
+        (result.GetAllowableCosts(taxYearsFilter, AssetGroupType.LISTEDSHARES) + result.GetAllowableCosts(taxYearsFilter, AssetGroupType.OTHERASSETS)).ShouldBe(expectedTotalAllowableCost);
+        (result.GetDisposalProceeds(taxYearsFilter, AssetGroupType.LISTEDSHARES) + result.GetDisposalProceeds(taxYearsFilter, AssetGroupType.OTHERASSETS)).ShouldBe(expectedTotalProceeds);
     }
 
 


### PR DESCRIPTION
This commit refactors the `TradeCalculationResult` class and its related methods to utilize `AssetCategoryType` instead of `AssetGroupType`. Key changes include:

- Updated method names and property types in `TradeCalculationResult`.
- Adjusted method calls in `CalculationSummary.razor` to align with the new structure.
- Modified `PdfExportService` and `YearlyTaxSummarySection` to accommodate the refactored `TradeCalculationResult`.
- Revised `TaxYearCgtByTypeReportService` and `TaxYearReportService` to use the updated methods for retrieving statistics.
- Updated unit tests in `TradeCalculationResultTests` to ensure they validate the new method names and functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced tax calculation and reporting logic for a more dynamic and accurate display of disposals, proceeds, costs, gains, and losses.
  - Improved the tax summary view and PDF export sections to offer clearer breakdowns by asset category.
- **Tests**
  - Updated test cases to verify the refined calculation methods and ensure consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->