### PR TITLE
Fix option rollover to underlying

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Model/TaxEvents/Trade.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TaxEvents/Trade.cs
@@ -44,28 +44,20 @@ public record Trade : TaxEvent, ITextFilePrintable
     /// <para> positive = charge: take money from you. </para>
     /// <para> negative = rebate: give you money </para>
     /// </summary>
-    public ImmutableList<DescribedMoney> Expenses { get; init; } = [];
+    public ImmutableList<DescribedMoney> Expenses { get; set; } = [];
     public TradeReason TradeReason { get; set; } = TradeReason.OrderedTrade;
     /// <summary>
-    /// indicate if the cost of the option is added to this trade already or not.
-    /// </summary>
-    public bool OptionAttached { get; set; } = false;
-    /// <summary>
-    /// If a trade is a result of an option, the cost or premium received is rolled to the trade. 
+    /// Apply the tax effect that if a trade is a result of an option, the cost or premium received is rolled to the trade. 
     /// </summary>
     /// <param name="cost"></param>
     /// <param name="description"></param>
     public void AttachOptionTrade(WrappedMoney cost, string description)
     {
-        if (!OptionAttached)
+        if (AcquisitionDisposal == TradeType.DISPOSAL)
         {
-            GrossProceed = GrossProceed with
-            {
-                Amount = GrossProceed.Amount + cost.Convert(1 / GrossProceed.FxRate, GrossProceed.Amount.Currency),
-                Description = description
-            };
-            OptionAttached = true;
+            cost *= -1;
         }
+        Expenses = Expenses.Add(new DescribedMoney(cost.Amount, cost.Currency, GrossProceed.FxRate, description));
     }
     public virtual WrappedMoney NetProceed
     {

--- a/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/Options/OptionTradeTaxCalculation.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/Options/OptionTradeTaxCalculation.cs
@@ -140,7 +140,7 @@ public class OptionTradeTaxCalculation : TradeTaxCalculation
                 allowableCost -= exerciseAllowableCost;
                 additionalInformation += $"{OwnerExercisedQty} option exercised. ";
                 matchDisposalProceedQty -= OwnerExercisedQty;
-                AttachTradeToUnderlying(exerciseAllowableCost, $"Trade is created by option exercise of option on {Date:d}", TradeReason.OwnerExerciseOption);
+                AttachTradeToUnderlying(exerciseAllowableCost, $"Option premium adjustment due to execising option", TradeReason.OwnerExerciseOption);
             }
             if (OwnerExercisedQty > 0 && IsCashSettled) additionalInformation += $"{OwnerExercisedQty:F2} option cash settled.";
             TradeMatch tradeMatch = new()
@@ -169,6 +169,8 @@ public class OptionTradeTaxCalculation : TradeTaxCalculation
     /// <param name="tradeReason"></param>
     public void AttachTradeToUnderlying(WrappedMoney attachedPremium, string comment, TradeReason tradeReason)
     {
+        // if you are assigned a put, you buy the underlying asset and the premium you received when you wrote the put is deducted from the acquisition cost
+        // if you are execising a put, you sell the underlying asset and the premium you pay when you buy the put is deducted from the disposal proceed
         if (PUTCALL == PUTCALL.PUT) attachedPremium = attachedPremium * -1;
         OptionTrade exerciseTrade = (OptionTrade)TradeList.First(trade => ((OptionTrade)trade).ExerciseOrExercisedTrade?.TradeReason == tradeReason);
         exerciseTrade.ExerciseOrExercisedTrade!.AttachOptionTrade(attachedPremium, comment);

--- a/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/Options/UkOptionTradeCalculator.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/Options/UkOptionTradeCalculator.cs
@@ -174,11 +174,8 @@ public class UkOptionTradeCalculator(UkSection104Pools section104Pools, ITradeAn
         {
             WrappedMoney premiumCost = tradePairSorter.EarlierTrade.GetProportionedCostOrProceed(exercisedQty);
             // If there is mutiple exercise trades it doesn't matter which trade to roll up, as all trades are the same ticker and same day are treated as a sigle trade.
-            tradePairSorter.LatterTrade.AttachTradeToUnderlying(premiumCost,
-                $"Trade is created by option exercise of option with premium {premiumCost} added(subtracted) on {tradePairSorter.LatterTrade.Date:d}",
-                TradeReason.OwnerExerciseOption);
-            tradeMatch = CreateTradeMatch(tradePairSorter, exercisedQty, WrappedMoney.GetBaseCurrencyZero(), WrappedMoney.GetBaseCurrencyZero(),
-                $"{exercisedQty} option exercised.", taxMatchType);
+            tradePairSorter.LatterTrade.AttachTradeToUnderlying(premiumCost, $"Option premium adjustment due to execising option", TradeReason.OwnerExerciseOption);
+            tradeMatch = CreateTradeMatch(tradePairSorter, exercisedQty, WrappedMoney.GetBaseCurrencyZero(), WrappedMoney.GetBaseCurrencyZero(), $"{exercisedQty} option exercised.", taxMatchType);
         }
         AssignTradeMatch(tradePairSorter, exercisedQty, tradeMatch, tradeMatch);
     }
@@ -206,8 +203,7 @@ public class UkOptionTradeCalculator(UkSection104Pools section104Pools, ITradeAn
         {
             WrappedMoney premiumCost = tradePairSorter.EarlierTrade.GetProportionedCostOrProceed(assignmentQty);
             // If there is mutiple exercise trades it doesn't matter which trade to roll up, as all trades are the same ticker and same day are treated as a sigle trade.
-            tradePairSorter.LatterTrade.AttachTradeToUnderlying(premiumCost, $"Trade is created by option assignment of option on {tradePairSorter.LatterTrade.Date:d}. \n" +
-                                      $"{premiumCost} is added(subtracted) to the trade amount.", TradeReason.OptionAssigned);
+            tradePairSorter.LatterTrade.AttachTradeToUnderlying(premiumCost, $"Option premium adjustment due to option assignment", TradeReason.OptionAssigned);
             if (!RefundIfNotInSameYear(tradePairSorter, taxYear, premiumCost))
             {
                 tradePairSorter.EarlierTrade.RefundDisposalQty(assignmentQty);

--- a/UnitTest/Test/TradeCalculations/Options/UkTradeCalculatorOptionMixedTest.cs
+++ b/UnitTest/Test/TradeCalculations/Options/UkTradeCalculatorOptionMixedTest.cs
@@ -164,7 +164,7 @@ public class UkTradeCalculatorOptionMixedTest
             Multiplier = 100,
             TradeReason = TradeReason.OrderedTrade,
             Quantity = 2,
-            GrossProceed = new DescribedMoney(1000, "USD", 0.78m),
+            GrossProceed = new DescribedMoney(1000, "USD", 0.78m), // net after expense 995 * 0.78 = £776.1
             Expenses = [new DescribedMoney(5, "USD", 0.78m)],
             AcquisitionDisposal = TradeType.DISPOSAL,
             Description = "Short AAPL 125 Call Option"
@@ -181,7 +181,7 @@ public class UkTradeCalculatorOptionMixedTest
             Multiplier = 100,
             TradeReason = TradeReason.OrderedTrade,
             Quantity = 4,
-            GrossProceed = new DescribedMoney(1500, "USD", 0.85m),
+            GrossProceed = new DescribedMoney(1500, "USD", 0.85m), // net after expense 1496 * 0.85 = £1271.6
             Expenses = [new DescribedMoney(4, "USD", 0.85m)],
             AcquisitionDisposal = TradeType.DISPOSAL,
             Description = "Short AAPL 125 Call Option #2"
@@ -261,6 +261,6 @@ public class UkTradeCalculatorOptionMixedTest
         disposeOptionTradeResult2.TotalProceeds.Amount.ShouldBe(847.73m, 0.01m); // 1496 * 0.85 * 4 / 6 ( 2 out of 6 option disposed is assigned and the premium goes to the underlying )
         var disposeTradeResult = result.Find(trade => trade is TradeTaxCalculation { AssetName: "AAPL", AcquisitionDisposal: TradeType.DISPOSAL, TotalQty: 200 });
         disposeTradeResult!.TotalAllowableCost.ShouldBe(new WrappedMoney(22000));
-        disposeTradeResult.TotalProceeds.Amount.ShouldBe(20423.87m, 0.01m);
+        disposeTradeResult.TotalProceeds.Amount.ShouldBe(20682.57m, 0.01m); // (776.1 + 1271.6) / 6 * 2 + 22000 = 22682.5666667
     }
 }


### PR DESCRIPTION
Fixed the case where 2 or more option trades get rollover to an underlying trade, only the premium for the first one is added/removed.

Shorten the comment label on option trades rollover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced expense processing for option trades, allowing adjustments after trade creation.
  - Streamlined premium adjustment notifications for both exercised and assigned options to improve clarity.
- **Tests**
  - Updated validation scenarios to reflect the refined expense and proceeds calculations, ensuring accurate tax result computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->