### PR TITLE
Fix handling of "Short " prefix in AssetName

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/UkMatchingRules.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/UkMatchingRules.cs
@@ -131,6 +131,7 @@ public static class UkMatchingRules
         foreach (var trade in trades.OrderBy(trade => trade.Date))
         {
             // run through trades chronologically and catagorise trades to one of the 4 catagories.
+            string shortPrefix = "Short ";
             switch (currentPosition, trade.RawQuantity)
             {
                 case ( >= 0, >= 0): // increase long position
@@ -143,12 +144,14 @@ public static class UkMatchingRules
                     break;
                 case ( <= 0, <= 0): // increase short position
                     trade.PositionType = PositionType.OPENSHORT;
-                    trade.AssetName = "Short " + trade.AssetName;
+                    if (!trade.AssetName.StartsWith(shortPrefix))
+                        trade.AssetName = shortPrefix + trade.AssetName;
                     resultList.Add(trade);
                     break;
                 case var (position, rawQuantity) when position <= 0 && rawQuantity <= Math.Abs(position): // closing only part or all of a short position.
                     trade.PositionType = PositionType.CLOSESHORT;
-                    trade.AssetName = "Short " + trade.AssetName;
+                    if (!trade.AssetName.StartsWith(shortPrefix))
+                        trade.AssetName = shortPrefix + trade.AssetName;
                     resultList.Add(trade);
                     break;
                 case var (position, rawQuantity) when position > 0 && rawQuantity < 0 && Math.Abs(rawQuantity) > position:
@@ -157,7 +160,8 @@ public static class UkMatchingRules
                     closingTrade.PositionType = PositionType.CLOSELONG;
                     T reopeningTrade = trade.SplitTrade(Math.Abs(rawQuantity) - Math.Abs(currentPosition));
                     reopeningTrade.PositionType = PositionType.OPENSHORT;
-                    reopeningTrade.AssetName = "Short " + trade.AssetName;
+                    if (!reopeningTrade.AssetName.StartsWith(shortPrefix))
+                        reopeningTrade.AssetName = shortPrefix + trade.AssetName;
                     resultList.Add(reopeningTrade);
                     resultList.Add(closingTrade);
                     break;
@@ -165,7 +169,8 @@ public static class UkMatchingRules
                     // closing a short position and reopen as a long
                     closingTrade = trade.SplitTrade(Math.Abs(currentPosition));
                     closingTrade.PositionType = PositionType.CLOSESHORT;
-                    closingTrade.AssetName = "Short " + trade.AssetName;
+                    if (!closingTrade.AssetName.StartsWith(shortPrefix))
+                        closingTrade.AssetName = shortPrefix + trade.AssetName;
                     reopeningTrade = trade.SplitTrade(Math.Abs(rawQuantity) - Math.Abs(currentPosition));
                     reopeningTrade.PositionType = PositionType.OPENLONG;
                     resultList.Add(reopeningTrade);


### PR DESCRIPTION
Prevent duplicate "Short " prefixes by checking if AssetName already starts with the prefix before adding it for short trades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected asset naming for short positions to prevent duplicate prefixes. Asset names are now consistently labeled and properly associated with their corresponding trades.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->