### PR TITLE
Add guidance and key terms to ResidencyStatusPage

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Pages/ResidencyStatusPage.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/ResidencyStatusPage.razor
@@ -2,5 +2,27 @@
 @using InvestmentTaxCalculator.Components
 
 <div class="container mt-4 mb-4">
+    <div class="mb-3">
+        <h5>How to use this tool</h5>
+        <p class="mb-1">Pick a Start and End date (use the "Unbounded" checkbox for open-ended ranges), select a residency status from the dropdown, then click 
+            <em>Set residency for range</em>. Use <em>Reset</em> to clear the inputs. The timeline visualizes all configured ranges and the grid below lists them. To remove an entry, overwrite the time period with the updated status.</p>
+
+        <h6 class="mt-2">Key terms</h6>
+        <ul class="mb-0">
+            <li><strong>Resident</strong>: the person is tax resident during the range; gains are generally subject to UK taxation for that period. This also includes the resident part of a split year treatment.</li>
+            <li><strong>Temporary non-resident</strong>: a short-term non-residence period where different or transitional tax rules may apply; some disposals might still be taxed depending on timing. This also includes the non-resident part of a split year treatment.</li>
+            <li><strong>Non-resident</strong>: the person is not tax resident during the range; UK capital gains tax may not apply to some assets or disposals while non‑resident (subject to specific rules). This also includes the non-resident part of a split year treatment.</li>
+        </ul>
+    </div>
+
+    <div class="alert alert-warning">
+        <strong>Note:</strong> Decide whether a period should be marked <strong>Non‑resident</strong> or <strong>Temporary non‑resident</strong>.
+        This tool does not determine residency status — choose the most appropriate option for your circumstances or consult a tax adviser.
+    </div>
+
+    <p class="small text-muted">
+        Reference: HMRC HS278 (2025) — <a href="https://www.gov.uk/government/publications/temporary-non-residents-and-capital-gains-tax-hs278-self-assessment-helpsheet/hs278-temporary-non-residents-and-capital-gains-tax-2025" target="_blank" rel="noopener noreferrer">Temporary non-residents and Capital Gains Tax</a>.
+    </p>
+
     <ResidencyStatusInput />
 </div>


### PR DESCRIPTION
Enhanced the ResidencyStatusPage with the following updates:
- Added a "How to use this tool" section with usage instructions.
- Introduced a "Key terms" subsection defining residency statuses.
- Added a warning alert about determining residency status.
- Included a reference link to HMRC HS278 (2025) for further info.
- Updated the layout to integrate the new content seamlessly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive instructional content to the Residency Status page including: step-by-step usage guidance (inputs, actions, reset behavior), clear definitions of residency status categories (Resident, Temporary non-resident, Non-resident), important advisory notes on residency marking decisions, and current HMRC HS278 tax reference material.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->