### PR TITLE
Revamp whole add manual trade page

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Components/AssetNameSelector.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/AssetNameSelector.razor
@@ -13,8 +13,7 @@
             AllowCustom="@AllowManualAssetNameInput"
             Placeholder="@Placeholder"
             CssClass="@CssClass"
-            Enabled="@Enabled"
-            AllowFiltering="true">
+            Enabled="@Enabled">
     <ComboBoxEvents TValue="string" TItem="string" ValueChange="@OnValueChangedInternal" />
 </SfComboBox>
 
@@ -33,10 +32,16 @@
     [Parameter] public bool Enabled { get; set; } = true;
 
     private List<string> _assetNames = [];
+    private string _lastDataSignature = string.Empty;
 
     protected override void OnParametersSet()
     {
-        RefreshAssetNames();
+        var dataSignature = BuildDataSignature();
+        if (!string.Equals(_lastDataSignature, dataSignature, StringComparison.Ordinal))
+        {
+            RefreshAssetNames();
+            _lastDataSignature = dataSignature;
+        }
     }
 
     private void RefreshAssetNames()
@@ -94,8 +99,35 @@
             .ToList();
     }
 
+    private string BuildDataSignature()
+    {
+        var orderedAssetCategories = (AssetCategoryFilter ?? [])
+            .Distinct()
+            .OrderBy(c => c)
+            .Select(c => c.ToString());
+        var orderedIncludedAssets = (IncludedAssetNames ?? [])
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase);
+
+        int poolCount = Section104Pools.GetSection104s().Count;
+        return string.Join('|',
+            string.Join(',', orderedAssetCategories),
+            string.Join(',', orderedIncludedAssets),
+            HoldingDate?.Date.ToString("yyyy-MM-dd") ?? string.Empty,
+            RequirePositiveHoldingOnDate.ToString(),
+            poolCount.ToString(),
+            TaxEventLists.Trades.Count.ToString(),
+            TaxEventLists.OptionTrades.Count.ToString(),
+            TaxEventLists.FutureContractTrades.Count.ToString());
+    }
+
     private async Task OnValueChangedInternal(ChangeEventArgs<string, string> args)
     {
-        await ValueChanged.InvokeAsync(args.Value ?? string.Empty);
+        string nextValue = args.Value ?? string.Empty;
+        if (!string.Equals(nextValue, Value, StringComparison.Ordinal))
+        {
+            await ValueChanged.InvokeAsync(nextValue);
+        }
     }
 }

--- a/BlazorApp-Investment Tax Calculator/Components/AssetNameSelector.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/AssetNameSelector.razor
@@ -1,0 +1,101 @@
+@using InvestmentTaxCalculator.Enumerations
+@using InvestmentTaxCalculator.Model
+@using InvestmentTaxCalculator.Model.UkTaxModel
+@using Syncfusion.Blazor.DropDowns
+
+@inject UkSection104Pools Section104Pools
+@inject TaxEventLists TaxEventLists
+
+<SfComboBox TValue="string"
+            TItem="string"
+            DataSource="@_assetNames"
+            Value="@Value"
+            AllowCustom="@AllowManualAssetNameInput"
+            Placeholder="@Placeholder"
+            CssClass="@CssClass"
+            Enabled="@Enabled"
+            AllowFiltering="true">
+    <ComboBoxEvents TValue="string" TItem="string" ValueChange="@OnValueChangedInternal" />
+</SfComboBox>
+
+@code {
+    [Parameter] public string Value { get; set; } = string.Empty;
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+
+    [Parameter] public bool AllowManualAssetNameInput { get; set; } = true;
+    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [];
+    [Parameter] public List<string> IncludedAssetNames { get; set; } = [];
+    [Parameter] public DateTime? HoldingDate { get; set; }
+    [Parameter] public bool RequirePositiveHoldingOnDate { get; set; }
+
+    [Parameter] public string Placeholder { get; set; } = "Select asset";
+    [Parameter] public string CssClass { get; set; } = "e-outline";
+    [Parameter] public bool Enabled { get; set; } = true;
+
+    private List<string> _assetNames = [];
+
+    protected override void OnParametersSet()
+    {
+        RefreshAssetNames();
+    }
+
+    private void RefreshAssetNames()
+    {
+        var categoryFilter = AssetCategoryFilter?.Distinct().ToHashSet() ?? [];
+        bool hasCategoryFilter = categoryFilter.Count > 0;
+        var includedAssetNames = IncludedAssetNames?.ToHashSet(StringComparer.OrdinalIgnoreCase) ?? [];
+        bool hasIncludedAssetsFilter = includedAssetNames.Count > 0;
+
+        var allowedAssetNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (hasCategoryFilter)
+        {
+            if (categoryFilter.Contains(AssetCategoryType.STOCK))
+            {
+                foreach (string assetName in TaxEventLists.Trades.Where(t => t.AssetType == AssetCategoryType.STOCK).Select(t => t.AssetName))
+                {
+                    allowedAssetNames.Add(assetName);
+                }
+            }
+
+            if (categoryFilter.Contains(AssetCategoryType.OPTION))
+            {
+                foreach (string assetName in TaxEventLists.OptionTrades.Select(t => t.AssetName))
+                {
+                    allowedAssetNames.Add(assetName);
+                }
+            }
+
+            if (categoryFilter.Contains(AssetCategoryType.FUTURE))
+            {
+                foreach (string assetName in TaxEventLists.FutureContractTrades.Select(t => t.AssetName))
+                {
+                    allowedAssetNames.Add(assetName);
+                }
+            }
+
+            if (categoryFilter.Contains(AssetCategoryType.FX))
+            {
+                foreach (string assetName in TaxEventLists.Trades.Where(t => t.AssetType == AssetCategoryType.FX).Select(t => t.AssetName))
+                {
+                    allowedAssetNames.Add(assetName);
+                }
+            }
+        }
+
+        DateOnly? holdingDate = HoldingDate.HasValue ? DateOnly.FromDateTime(HoldingDate.Value) : null;
+
+        _assetNames = Section104Pools.GetSection104s()
+            .Where(pool => !hasCategoryFilter || allowedAssetNames.Contains(pool.AssetName))
+            .Where(pool => !hasIncludedAssetsFilter || includedAssetNames.Contains(pool.AssetName))
+            .Where(pool => !RequirePositiveHoldingOnDate || holdingDate == null || (pool.GetLastSection104History(holdingDate.Value)?.NewQuantity ?? 0) > 0)
+            .Select(pool => pool.AssetName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(assetName => assetName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private async Task OnValueChangedInternal(ChangeEventArgs<string, string> args)
+    {
+        await ValueChanged.InvokeAsync(args.Value ?? string.Empty);
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Components/CorporateActionHeader.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/CorporateActionHeader.razor
@@ -1,12 +1,12 @@
 @using InvestmentTaxCalculator.Model
 @using InvestmentTaxCalculator.Model.UkTaxModel
 @using InvestmentTaxCalculator.Services
+@using InvestmentTaxCalculator.Enumerations
 @using Syncfusion.Blazor.Calendars
 @using Syncfusion.Blazor.DropDowns
 @using Syncfusion.Blazor.Inputs
 
 @inject UkSection104Pools _ukSection104Pools
-@inject TradeCalculationResult _tradeCalculationResult
 
 <div class="row mb-3">
     <div class="col-md-6">
@@ -20,10 +20,11 @@
 <div class="row mb-3">
     <div class="col-md-6">
         <label class="form-label">@SourceLabel</label>
-        <SfDropDownList TValue="string" TItem="string" Placeholder="Select Asset" DataSource="@_availableAssets" Value="@SourceTicker">
-            <DropDownListFieldSettings Text="" Value=""></DropDownListFieldSettings>
-            <DropDownListEvents TItem="string" TValue="string" ValueChange="@OnSourceTickerChangedInternal"></DropDownListEvents>
-        </SfDropDownList>
+        <AssetNameSelector Value="@SourceTicker"
+                           ValueChanged="@OnSourceTickerChangedInternal"
+                           AllowManualAssetNameInput="@AllowManualSourceAssetNameInput"
+                           AssetCategoryFilter="@AssetCategoryFilter"
+                           Placeholder="Select Asset" />
         @if (!string.IsNullOrEmpty(SourceTicker))
         {
             <div class="form-text text-info">
@@ -33,9 +34,12 @@
     </div>
     <div class="col-md-6">
         <label class="form-label">@DestinationLabel</label>
-        <SfComboBox TValue="string" TItem="string" Placeholder="Select or Enter Ticker" DataSource="@_availableAssets" Value="@DestinationTicker" AllowCustom="true" Enabled="@(!IsDestinationDisabled)">
-            <ComboBoxEvents TItem="string" TValue="string" ValueChange="@OnDestinationTickerChangedInternal"></ComboBoxEvents>
-        </SfComboBox>
+        <AssetNameSelector Value="@DestinationTicker"
+                           ValueChanged="@OnDestinationTickerChangedInternal"
+                           AllowManualAssetNameInput="@AllowManualDestinationAssetNameInput"
+                           AssetCategoryFilter="@AssetCategoryFilter"
+                           Placeholder="Select or Enter Ticker"
+                           Enabled="@(!IsDestinationDisabled)" />
     </div>
 </div>
 
@@ -95,34 +99,19 @@
     [Parameter] public string DestinationUnitLabel { get; set; } = "shares";
     [Parameter] public RenderFragment? DestinationInfo { get; set; }
     [Parameter] public bool IsDestinationDisabled { get; set; }
+    [Parameter] public bool AllowManualSourceAssetNameInput { get; set; }
+    [Parameter] public bool AllowManualDestinationAssetNameInput { get; set; } = true;
+    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK];
     [Parameter] public int RatioDecimals { get; set; } = 4;
     [Parameter] public string RatioFormat { get; set; } = "n4";
     [Parameter] public decimal RatioMin { get; set; } = 0.0001m;
     [Parameter] public EventCallback OnInputsChanged { get; set; }
 
     public decimal CurrentHolding { get; private set; }
-    private List<string> _availableAssets = [];
-
-    protected override void OnInitialized()
-    {
-        RefreshAssets();
-        CalculateStats();
-    }
 
     protected override void OnParametersSet()
     {
         CalculateStats();
-    }
-
-    private void RefreshAssets()
-    {
-        if (_tradeCalculationResult.CalculatedTrade.Any())
-        {
-            _availableAssets = _ukSection104Pools.GetSection104s()
-                .Select(x => x.AssetName)
-                .OrderBy(x => x)
-                .ToList();
-        }
     }
 
     private void CalculateStats()
@@ -147,18 +136,18 @@
         await OnInputsChanged.InvokeAsync();
     }
 
-    private async Task OnSourceTickerChangedInternal(Syncfusion.Blazor.DropDowns.ChangeEventArgs<string, string> args)
+    private async Task OnSourceTickerChangedInternal(string ticker)
     {
-        SourceTicker = args.Value;
+        SourceTicker = ticker;
         CalculateStats();
-        await SourceTickerChanged.InvokeAsync(args.Value);
+        await SourceTickerChanged.InvokeAsync(ticker);
         await OnInputsChanged.InvokeAsync();
     }
 
-    private async Task OnDestinationTickerChangedInternal(Syncfusion.Blazor.DropDowns.ChangeEventArgs<string, string> args)
+    private async Task OnDestinationTickerChangedInternal(string ticker)
     {
-        DestinationTicker = args.Value;
-        await DestinationTickerChanged.InvokeAsync(args.Value);
+        DestinationTicker = ticker;
+        await DestinationTickerChanged.InvokeAsync(ticker);
         await OnInputsChanged.InvokeAsync();
     }
 

--- a/BlazorApp-Investment Tax Calculator/Components/EqualisationControl.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/EqualisationControl.razor
@@ -22,9 +22,14 @@
         <div class="row g-3">
             <div class="col-md-6 col-lg-4">
                 <label class="form-label">Ticker</label>
-                <SfDropDownList TValue="string" TItem="string" DataSource="@AvailableTickers" @bind-Value="@SelectedTicker" Placeholder="Select a ticker" CssClass="e-outline" Enabled="@(!IsCalculationMissing)">
-                    <DropDownListEvents TValue="string" TItem="string" ValueChange="OnTickerChanged"></DropDownListEvents>
-                </SfDropDownList>
+                <AssetNameSelector Value="@SelectedTicker"
+                                   ValueChanged="@OnTickerChanged"
+                                   AllowManualAssetNameInput="@AllowManualAssetNameInput"
+                                   AssetCategoryFilter="@AssetCategoryFilter"
+                                   IncludedAssetNames="@AvailableTickers"
+                                   Placeholder="Select a ticker"
+                                   CssClass="e-outline"
+                                   Enabled="@(!IsCalculationMissing)" />
             </div>
 
             @if (!string.IsNullOrEmpty(SelectedTicker))
@@ -70,6 +75,8 @@
 @code {
     [Parameter] public bool IsCalculationMissing { get; set; }
     [Parameter] public EventCallback OnDataChanged { get; set; }
+    [Parameter] public bool AllowManualAssetNameInput { get; set; }
+    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK];
 
     private List<string> AvailableTickers { get; set; } = new();
     private string SelectedTicker { get; set; } = string.Empty;
@@ -104,13 +111,14 @@
         Currencies = CurrencyService.GetCurrencies();
     }
 
-    private void OnTickerChanged(ChangeEventArgs<string, string> args)
+    private Task OnTickerChanged(string ticker)
     {
-        SelectedTicker = args.Value;
+        SelectedTicker = ticker;
         SelectedEventId = null;
         Currency = "GBP";
         FxRate = 1.0m;
         RefreshAvailableEvents();
+        return Task.CompletedTask;
     }
 
     private void OnEventSelected(ChangeEventArgs<int?, IncomeEventVM> args)

--- a/BlazorApp-Investment Tax Calculator/Components/EriControl.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/EriControl.razor
@@ -29,9 +29,15 @@
             {
                 <div class="col-md-6 col-lg-4">
                     <label class="form-label">Ticker</label>
-                    <SfDropDownList TValue="string" TItem="string" DataSource="@AvailableTickers" @bind-Value="@SelectedTicker" Placeholder="Select a ticker" CssClass="e-outline" Enabled="@(!IsCalculationMissing)">
-                        <DropDownListEvents TValue="string" TItem="string" ValueChange="OnTickerChanged"></DropDownListEvents>
-                    </SfDropDownList>
+                    <AssetNameSelector Value="@SelectedTicker"
+                                       ValueChanged="@OnTickerChanged"
+                                       AllowManualAssetNameInput="@AllowManualAssetNameInput"
+                                       AssetCategoryFilter="@AssetCategoryFilter"
+                                       HoldingDate="@PeriodEndDate"
+                                       RequirePositiveHoldingOnDate="true"
+                                       Placeholder="Select a ticker"
+                                       CssClass="e-outline"
+                                       Enabled="@(!IsCalculationMissing)" />
                 </div>
 
                 @if (!string.IsNullOrEmpty(SelectedTicker))
@@ -88,9 +94,10 @@
 @code {
     [Parameter] public bool IsCalculationMissing { get; set; }
     [Parameter] public EventCallback OnDataChanged { get; set; }
+    [Parameter] public bool AllowManualAssetNameInput { get; set; }
+    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK];
 
     private DateTime? PeriodEndDate { get; set; }
-    private List<string> AvailableTickers { get; set; } = new();
     private string SelectedTicker { get; set; } = string.Empty;
     private decimal Quantity { get; set; }
     private decimal IncomePerShare { get; set; }
@@ -110,34 +117,24 @@
     {
         PeriodEndDate = date;
         SelectedTicker = string.Empty;
-        AvailableTickers.Clear();
-        if (date.HasValue)
-        {
-            var dateOnly = DateOnly.FromDateTime(date.Value);
-            var pools = Section104Pools.GetSection104s();
-            foreach (var pool in pools)
-            {
-                var history = pool.GetLastSection104History(dateOnly);
-                if (history != null && history.NewQuantity > 0)
-                {
-                    if (TaxEventLists.Trades.Any(t => t.AssetName == pool.AssetName && t.AssetType == AssetCategoryType.STOCK))
-                    {
-                        AvailableTickers.Add(pool.AssetName);
-                    }
-                }
-            }
-        }
+        Quantity = 0m;
     }
 
-    private void OnTickerChanged(ChangeEventArgs<string, string> args)
+    private Task OnTickerChanged(string ticker)
     {
-        SelectedTicker = args.Value;
+        SelectedTicker = ticker;
         if (!string.IsNullOrEmpty(SelectedTicker) && PeriodEndDate.HasValue)
         {
             var pool = Section104Pools.GetExistingOrInitialise(SelectedTicker);
             var history = pool.GetLastSection104History(DateOnly.FromDateTime(PeriodEndDate.Value));
             Quantity = history?.NewQuantity ?? 0;
         }
+        else
+        {
+            Quantity = 0m;
+        }
+
+        return Task.CompletedTask;
     }
 
     private string GetIsinForTicker(string ticker)
@@ -153,7 +150,7 @@
 
     private async Task OnSubmit()
     {
-        if (!PeriodEndDate.HasValue || string.IsNullOrEmpty(SelectedTicker) || IncomePerShare <= 0 || FxRate <= 0)
+        if (!PeriodEndDate.HasValue || string.IsNullOrEmpty(SelectedTicker) || Quantity <= 0 || IncomePerShare <= 0 || FxRate <= 0)
         {
             ToastService.ShowError("Please fill in all fields correctly.");
             return;

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/AmountCurrencyFxInputRow.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/AmountCurrencyFxInputRow.razor
@@ -9,8 +9,8 @@
             <label class="form-label d-block">Amount</label>
             <SfNumericTextBox TValue="decimal"
                               Value="@Amount"
-                              Decimals="@AmountDecimals"
-                              Format="@AmountFormat"
+                              Decimals="8"
+                              Format="0.########"
                               ShowSpinButton="false"
                               CssClass="e-outline e-small">
                 <NumericTextBoxEvents TValue="decimal" ValueChange="@OnAmountChanged"></NumericTextBoxEvents>
@@ -34,8 +34,8 @@
             <label class="form-label d-block">@FxRateLabel</label>
             <SfNumericTextBox TValue="decimal"
                               Value="@FxRate"
-                              Decimals="@FxRateDecimals"
-                              Format="@FxRateFormat"
+                              Decimals="8"
+                              Format="0.########"
                               ShowSpinButton="false"
                               CssClass="e-outline e-small">
                 <NumericTextBoxEvents TValue="decimal" ValueChange="@OnFxRateChanged"></NumericTextBoxEvents>
@@ -61,11 +61,6 @@
     [Parameter] public EventCallback<decimal> FxRateChanged { get; set; }
 
     [Parameter] public IEnumerable<CurrencyViewModel> Currencies { get; set; } = [];
-
-    [Parameter] public int AmountDecimals { get; set; } = 8;
-    [Parameter] public string AmountFormat { get; set; } = "N8";
-    [Parameter] public int FxRateDecimals { get; set; } = 8;
-    [Parameter] public string FxRateFormat { get; set; } = "N8";
 
     private string EntryTitle => string.IsNullOrWhiteSpace(Title) ? AmountLabel : Title!;
 

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/AmountCurrencyFxInputRow.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/AmountCurrencyFxInputRow.razor
@@ -6,7 +6,7 @@
     <div class="manual-money-entry-title">@EntryTitle</div>
     <div class="row g-2 manual-money-row">
         <div class="col-12 col-md-4 col-lg-4">
-            <label class="form-label d-block">Amount</label>
+            <label class="form-label d-block">@AmountLabel</label>
             <SfNumericTextBox TValue="decimal"
                               Value="@Amount"
                               Decimals="8"

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/AmountCurrencyFxInputRow.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/AmountCurrencyFxInputRow.razor
@@ -1,0 +1,86 @@
+@using InvestmentTaxCalculator.Services
+@using Syncfusion.Blazor.DropDowns
+@using Syncfusion.Blazor.Inputs
+
+<div class="manual-money-entry @AdditionalCssClass">
+    <div class="manual-money-entry-title">@EntryTitle</div>
+    <div class="row g-2 manual-money-row">
+        <div class="col-12 col-md-4 col-lg-4">
+            <label class="form-label d-block">Amount</label>
+            <SfNumericTextBox TValue="decimal"
+                              Value="@Amount"
+                              Decimals="@AmountDecimals"
+                              Format="@AmountFormat"
+                              ShowSpinButton="false"
+                              CssClass="e-outline e-small">
+                <NumericTextBoxEvents TValue="decimal" ValueChange="@OnAmountChanged"></NumericTextBoxEvents>
+            </SfNumericTextBox>
+        </div>
+
+        <div class="col-12 col-md-4 col-lg-4">
+            <label class="form-label d-block">@CurrencyLabel</label>
+            <SfDropDownList TValue="string"
+                            TItem="CurrencyViewModel"
+                            DataSource="@Currencies"
+                            Value="@Currency"
+                            CssClass="e-outline e-small"
+                            PopupHeight="260px">
+                <DropDownListFieldSettings Text="Code" Value="Code"></DropDownListFieldSettings>
+                <DropDownListEvents TValue="string" TItem="CurrencyViewModel" ValueChange="@OnCurrencyChanged"></DropDownListEvents>
+            </SfDropDownList>
+        </div>
+
+        <div class="col-12 col-md-4 col-lg-4">
+            <label class="form-label d-block">@FxRateLabel</label>
+            <SfNumericTextBox TValue="decimal"
+                              Value="@FxRate"
+                              Decimals="@FxRateDecimals"
+                              Format="@FxRateFormat"
+                              ShowSpinButton="false"
+                              CssClass="e-outline e-small">
+                <NumericTextBoxEvents TValue="decimal" ValueChange="@OnFxRateChanged"></NumericTextBoxEvents>
+            </SfNumericTextBox>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public string AmountLabel { get; set; } = "Amount";
+    [Parameter] public string? Title { get; set; }
+    [Parameter] public string CurrencyLabel { get; set; } = "Currency";
+    [Parameter] public string FxRateLabel { get; set; } = "FX Rate (to GBP)";
+    [Parameter] public string AdditionalCssClass { get; set; } = string.Empty;
+
+    [Parameter] public decimal Amount { get; set; }
+    [Parameter] public EventCallback<decimal> AmountChanged { get; set; }
+
+    [Parameter] public string Currency { get; set; } = "GBP";
+    [Parameter] public EventCallback<string> CurrencyChanged { get; set; }
+
+    [Parameter] public decimal FxRate { get; set; } = 1m;
+    [Parameter] public EventCallback<decimal> FxRateChanged { get; set; }
+
+    [Parameter] public IEnumerable<CurrencyViewModel> Currencies { get; set; } = [];
+
+    [Parameter] public int AmountDecimals { get; set; } = 8;
+    [Parameter] public string AmountFormat { get; set; } = "N8";
+    [Parameter] public int FxRateDecimals { get; set; } = 8;
+    [Parameter] public string FxRateFormat { get; set; } = "N8";
+
+    private string EntryTitle => string.IsNullOrWhiteSpace(Title) ? AmountLabel : Title!;
+
+    private async Task OnAmountChanged(Syncfusion.Blazor.Inputs.ChangeEventArgs<decimal> args)
+    {
+        await AmountChanged.InvokeAsync(args.Value);
+    }
+
+    private async Task OnCurrencyChanged(Syncfusion.Blazor.DropDowns.ChangeEventArgs<string, CurrencyViewModel> args)
+    {
+        await CurrencyChanged.InvokeAsync(args.Value ?? "GBP");
+    }
+
+    private async Task OnFxRateChanged(Syncfusion.Blazor.Inputs.ChangeEventArgs<decimal> args)
+    {
+        await FxRateChanged.InvokeAsync(args.Value);
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
@@ -209,6 +209,7 @@
         _isin = string.Empty;
         _description = string.Empty;
     }
+
     private sealed record CountryCodeOption(string ThreeDigitCode, string CountryName)
     {
         public string Display => $"{ThreeDigitCode} - {CountryName}";

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
@@ -126,7 +126,7 @@
         if (EditingTaxEventId.HasValue)
         {
             int removed = TaxEventLists.Dividends.RemoveAll(d => d.Id == EditingTaxEventId.Value);
-            if (removed == 0)
+            if (removed != 1)
             {
                 ToastService.ShowError("Unable to update dividend because the original entry could not be found.");
                 return;

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
@@ -1,0 +1,182 @@
+@using InvestmentTaxCalculator.Enumerations
+@using InvestmentTaxCalculator.Model
+@using InvestmentTaxCalculator.Model.TaxEvents
+@using InvestmentTaxCalculator.Services
+@using Syncfusion.Blazor.Buttons
+@using Syncfusion.Blazor.DropDowns
+@using Syncfusion.Blazor.Inputs
+
+@inject TaxEventLists TaxEventLists
+@inject CurrencyService CurrencyService
+@inject ToastService ToastService
+
+<div class="card bg-secondary text-white">
+    <div class="card-header bg-info text-dark">
+        <h5 class="mb-0">Add Dividend</h5>
+    </div>
+    <div class="card-body">
+        <ManualEntryCommonFields Date="@_date"
+                                 DateChanged="@((DateTime value) => _date = value)"
+                                 AssetName="@_assetName"
+                                 AssetNameChanged="@((string value) => _assetName = value)"
+                                 AssetSuggestions="@_assetSuggestions" />
+
+        <div class="row g-3 mt-1">
+            <div class="col-md-4">
+                <label class="form-label">Dividend Type</label>
+                <SfDropDownList TValue="DividendType" TItem="EnumDescriptionPair<DividendType>" DataSource="@_dividendTypes" @bind-Value="@_dividendType" CssClass="e-outline e-small">
+                    <DropDownListFieldSettings Text="Description" Value="EnumValue"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Company Location</label>
+                <SfDropDownList TValue="string" TItem="CountryCodeOption" DataSource="@_countryCodes" @bind-Value="@_companyLocationCode" CssClass="e-outline e-small" PopupHeight="260px" AllowFiltering="true" Placeholder="Select country">
+                    <DropDownListFieldSettings Text="Display" Value="ThreeDigitCode"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">ISIN (optional)</label>
+                <SfTextBox @bind-Value="@_isin" Placeholder="Optional ISIN" FloatLabelType="FloatLabelType.Never"></SfTextBox>
+            </div>
+            <div class="col-md-8">
+                <label class="form-label">Description</label>
+                <SfTextBox @bind-Value="@_description" Placeholder="Optional note" FloatLabelType="FloatLabelType.Never"></SfTextBox>
+            </div>
+        </div>
+
+        <AmountCurrencyFxInputRow AmountLabel="Amount"
+                                  FxRateLabel="FX Rate (to GBP)"
+                                  @bind-Amount="@_amount"
+                                  @bind-Currency="@_currency"
+                                  @bind-FxRate="@_fxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-3" />
+
+        @if (CanShowCalculationPreview)
+        {
+            <div class="alert alert-dark border-info mt-4 mb-0">
+                <div class="row g-2">
+                    <div class="col-md-4"><strong>Amount (GBP):</strong> @AmountInGbp.ToString("N2")</div>
+                    <div class="col-md-4"><strong>Dividend Received (GBP):</strong> @DividendReceivedInGbp.ToString("N2")</div>
+                    <div class="col-md-4"><strong>Withholding Tax (GBP):</strong> @WithholdingTaxInGbp.ToString("N2")</div>
+                </div>
+            </div>
+        }
+
+        <div class="col-12 mt-4 d-flex justify-content-center">
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-info e-large text-dark">Add Dividend</SfButton>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback OnEntryAdded { get; set; }
+
+    private DateTime _date = DateTime.Today;
+    private string _assetName = string.Empty;
+    private DividendType _dividendType = DividendType.DIVIDEND;
+    private decimal _amount;
+    private string _currency = "GBP";
+    private decimal _fxRate = 1m;
+    private string _companyLocationCode = CountryCode.UnknownRegion.ThreeDigitCode;
+    private string _isin = string.Empty;
+    private string _description = string.Empty;
+
+    private List<CurrencyViewModel> _currencies = [];
+    private List<string> _assetSuggestions = [];
+    private List<EnumDescriptionPair<DividendType>> _dividendTypes = [];
+    private List<CountryCodeOption> _countryCodes = [];
+
+    private decimal AmountInGbp => _amount * _fxRate;
+    private decimal DividendReceivedInGbp => _dividendType is DividendType.DIVIDEND or DividendType.DIVIDEND_IN_LIEU or DividendType.EXCESS_REPORTABLE_INCOME or DividendType.RETURN_OF_CAPITAL
+        ? AmountInGbp
+        : 0m;
+    private decimal WithholdingTaxInGbp => _dividendType == DividendType.WITHHOLDING ? AmountInGbp : 0m;
+    private bool CanShowCalculationPreview => _amount != 0 && _fxRate > 0;
+
+    protected override void OnInitialized()
+    {
+        _currencies = CurrencyService.GetCurrencies();
+        _dividendTypes = EnumExtensions.GetEnumDescriptionPair<DividendType>(typeof(DividendType));
+        _countryCodes = CountryCode.GetAllRegions()
+            .Select(c => new CountryCodeOption(c.ThreeDigitCode, c.CountryName))
+            .ToList();
+        RefreshAssetSuggestions();
+    }
+
+    private async Task AddEntry()
+    {
+        if (!ValidateInputs(out CountryCode countryCode))
+        {
+            return;
+        }
+
+        var dividend = new Dividend
+        {
+            AssetName = _assetName.Trim(),
+            Date = _date,
+            DividendType = _dividendType,
+            CompanyLocation = countryCode,
+            Isin = _isin.Trim(),
+            Proceed = new DescribedMoney(_amount, _currency, _fxRate, _description.Trim())
+        };
+
+        TaxEventLists.Dividends.Add(dividend);
+        RefreshAssetSuggestions();
+        ResetForm();
+
+        ToastService.ShowSuccess($"Dividend added. Amount in GBP: {dividend.Proceed.BaseCurrencyAmount}.");
+        await OnEntryAdded.InvokeAsync();
+    }
+
+    private bool ValidateInputs(out CountryCode countryCode)
+    {
+        countryCode = CountryCode.UnknownRegion;
+
+        if (string.IsNullOrWhiteSpace(_assetName))
+        {
+            ToastService.ShowError("Asset name is required.");
+            return false;
+        }
+
+        if (_amount == 0)
+        {
+            ToastService.ShowError("Amount cannot be 0.");
+            return false;
+        }
+
+        if (_fxRate <= 0)
+        {
+            ToastService.ShowError("FX rate must be greater than 0.");
+            return false;
+        }
+
+        countryCode = CountryCode.GetRegionByThreeDigitCode(_companyLocationCode);
+        return true;
+    }
+
+    private void ResetForm()
+    {
+        _assetName = string.Empty;
+        _amount = 0m;
+        _fxRate = 1m;
+        _companyLocationCode = CountryCode.UnknownRegion.ThreeDigitCode;
+        _isin = string.Empty;
+        _description = string.Empty;
+    }
+
+    private void RefreshAssetSuggestions()
+    {
+        _assetSuggestions = TaxEventLists.AllEvents
+            .Select(i => i.AssetName)
+            .Where(i => !string.IsNullOrWhiteSpace(i))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private sealed record CountryCodeOption(string ThreeDigitCode, string CountryName)
+    {
+        public string Display => $"{ThreeDigitCode} - {CountryName}";
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
@@ -146,7 +146,8 @@
         TaxEventLists.Dividends.Add(dividend);
         ResetForm();
 
-        ToastService.ShowSuccess($"Dividend added. Amount in GBP: {dividend.Proceed.BaseCurrencyAmount}.");
+        string verb = IsEditing ? "updated" : "added";
+        ToastService.ShowSuccess($"Dividend {verb}. Amount in GBP: {dividend.Proceed.BaseCurrencyAmount}.");
         await OnEntryAdded.InvokeAsync(dividend.Id);
     }
 

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
@@ -19,7 +19,8 @@
                                  DateChanged="@((DateTime value) => _date = value)"
                                  AssetName="@_assetName"
                                  AssetNameChanged="@((string value) => _assetName = value)"
-                                 AssetSuggestions="@_assetSuggestions" />
+                                 AllowManualAssetNameInput="true"
+                                 AssetCategoryFilter="@_assetCategoryFilter" />
 
         <div class="row g-3 mt-1">
             <div class="col-md-4">
@@ -83,9 +84,9 @@
     private string _description = string.Empty;
 
     private List<CurrencyViewModel> _currencies = [];
-    private List<string> _assetSuggestions = [];
     private List<EnumDescriptionPair<DividendType>> _dividendTypes = [];
     private List<CountryCodeOption> _countryCodes = [];
+    private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.STOCK];
 
     private decimal AmountInGbp => _amount * _fxRate;
     private decimal DividendReceivedInGbp => _dividendType is DividendType.DIVIDEND or DividendType.DIVIDEND_IN_LIEU or DividendType.EXCESS_REPORTABLE_INCOME or DividendType.RETURN_OF_CAPITAL
@@ -101,7 +102,6 @@
         _countryCodes = CountryCode.GetAllRegions()
             .Select(c => new CountryCodeOption(c.ThreeDigitCode, c.CountryName))
             .ToList();
-        RefreshAssetSuggestions();
     }
 
     private async Task AddEntry()
@@ -122,7 +122,6 @@
         };
 
         TaxEventLists.Dividends.Add(dividend);
-        RefreshAssetSuggestions();
         ResetForm();
 
         ToastService.ShowSuccess($"Dividend added. Amount in GBP: {dividend.Proceed.BaseCurrencyAmount}.");
@@ -164,17 +163,6 @@
         _isin = string.Empty;
         _description = string.Empty;
     }
-
-    private void RefreshAssetSuggestions()
-    {
-        _assetSuggestions = TaxEventLists.AllEvents
-            .Select(i => i.AssetName)
-            .Where(i => !string.IsNullOrWhiteSpace(i))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
     private sealed record CountryCodeOption(string ThreeDigitCode, string CountryName)
     {
         public string Display => $"{ThreeDigitCode} - {CountryName}";

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
@@ -12,7 +12,7 @@
 
 <div class="card bg-secondary text-white">
     <div class="card-header bg-info text-dark">
-        <h5 class="mb-0">Add Dividend</h5>
+        <h5 class="mb-0">@(IsEditing ? "Edit Dividend" : "Add Dividend")</h5>
     </div>
     <div class="card-body">
         <ManualEntryCommonFields Date="@_date"
@@ -65,13 +65,14 @@
         }
 
         <div class="col-12 mt-4 d-flex justify-content-center">
-            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-info e-large text-dark">Add Dividend</SfButton>
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-info e-large text-dark">@(IsEditing ? "Update Dividend" : "Add Dividend")</SfButton>
         </div>
     </div>
 </div>
 
 @code {
-    [Parameter] public EventCallback OnEntryAdded { get; set; }
+    [Parameter] public EventCallback<int> OnEntryAdded { get; set; }
+    [Parameter] public int? EditingTaxEventId { get; set; }
 
     private DateTime _date = DateTime.Today;
     private string _assetName = string.Empty;
@@ -87,6 +88,8 @@
     private List<EnumDescriptionPair<DividendType>> _dividendTypes = [];
     private List<CountryCodeOption> _countryCodes = [];
     private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.STOCK];
+    private int? _loadedEditingTaxEventId;
+    private bool IsEditing => EditingTaxEventId.HasValue;
 
     private decimal AmountInGbp => _amount * _fxRate;
     private decimal DividendReceivedInGbp => _dividendType is DividendType.DIVIDEND or DividendType.DIVIDEND_IN_LIEU or DividendType.EXCESS_REPORTABLE_INCOME or DividendType.RETURN_OF_CAPITAL
@@ -104,11 +107,30 @@
             .ToList();
     }
 
+    protected override void OnParametersSet()
+    {
+        if (_loadedEditingTaxEventId != EditingTaxEventId)
+        {
+            _loadedEditingTaxEventId = EditingTaxEventId;
+            LoadForEdit();
+        }
+    }
+
     private async Task AddEntry()
     {
         if (!ValidateInputs(out CountryCode countryCode))
         {
             return;
+        }
+
+        if (EditingTaxEventId.HasValue)
+        {
+            int removed = TaxEventLists.Dividends.RemoveAll(d => d.Id == EditingTaxEventId.Value);
+            if (removed == 0)
+            {
+                ToastService.ShowError("Unable to update dividend because the original entry could not be found.");
+                return;
+            }
         }
 
         var dividend = new Dividend
@@ -125,7 +147,31 @@
         ResetForm();
 
         ToastService.ShowSuccess($"Dividend added. Amount in GBP: {dividend.Proceed.BaseCurrencyAmount}.");
-        await OnEntryAdded.InvokeAsync();
+        await OnEntryAdded.InvokeAsync(dividend.Id);
+    }
+
+    private void LoadForEdit()
+    {
+        if (!EditingTaxEventId.HasValue)
+        {
+            return;
+        }
+
+        Dividend? dividend = TaxEventLists.Dividends.FirstOrDefault(d => d.Id == EditingTaxEventId.Value);
+        if (dividend == null)
+        {
+            return;
+        }
+
+        _date = dividend.Date;
+        _assetName = dividend.AssetName;
+        _dividendType = dividend.DividendType;
+        _amount = dividend.Proceed.Amount.Amount;
+        _currency = dividend.Proceed.Amount.Currency;
+        _fxRate = dividend.Proceed.FxRate;
+        _companyLocationCode = dividend.CompanyLocation.ThreeDigitCode;
+        _isin = dividend.Isin;
+        _description = dividend.Proceed.Description;
     }
 
     private bool ValidateInputs(out CountryCode countryCode)

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
@@ -92,7 +92,7 @@
         ? AmountInGbp
         : 0m;
     private decimal WithholdingTaxInGbp => _dividendType == DividendType.WITHHOLDING ? AmountInGbp : 0m;
-    private bool CanShowCalculationPreview => _amount != 0 && _fxRate > 0;
+    private bool CanShowCalculationPreview => _amount > 0 && _fxRate > 0;
 
     protected override void OnInitialized()
     {
@@ -139,9 +139,9 @@
             return false;
         }
 
-        if (_amount == 0)
+        if (_amount <= 0)
         {
-            ToastService.ShowError("Amount cannot be 0.");
+            ToastService.ShowError("Amount must be greater than 0.");
             return false;
         }
 

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
@@ -134,7 +134,7 @@
         if (EditingTaxEventId.HasValue)
         {
             int removed = TaxEventLists.FutureContractTrades.RemoveAll(t => t.Id == EditingTaxEventId.Value);
-            if (removed == 0)
+            if (removed != 1)
             {
                 ToastService.ShowError("Unable to update future contract trade because the original entry could not be found.");
                 return;

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
@@ -32,7 +32,7 @@
             </div>
             <div class="col-md-4">
                 <label class="form-label">Quantity (contracts)</label>
-                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="N8" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="0.########" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
             </div>
             <div class="col-md-6">
                 <label class="form-label">Description</label>
@@ -261,5 +261,6 @@
         _taxFxRate = 1m;
         _description = string.Empty;
     }
+
     private sealed record DirectionOption(string Value, string Display);
 }

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
@@ -170,7 +170,8 @@
         TaxEventLists.FutureContractTrades.Add(trade);
         ResetForm();
 
-        ToastService.ShowSuccess($"Future contract trade added. Contract value in GBP: {trade.ContractValue.BaseCurrencyAmount}.");
+        string verb = IsEditing ? "updated" : "added";
+        ToastService.ShowSuccess($"Future contract trade {verb}. Contract value in GBP: {trade.ContractValue.BaseCurrencyAmount}.");
         await OnEntryAdded.InvokeAsync(trade.Id);
     }
 

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
@@ -13,7 +13,7 @@
 
 <div class="card bg-secondary text-white">
     <div class="card-header bg-warning text-dark">
-        <h5 class="mb-0">Add Future Contract Trade</h5>
+        <h5 class="mb-0">@(IsEditing ? "Edit Future Contract Trade" : "Add Future Contract Trade")</h5>
     </div>
     <div class="card-body">
         <ManualEntryCommonFields Date="@_date"
@@ -76,13 +76,14 @@
         }
 
         <div class="col-12 mt-4 d-flex justify-content-center">
-            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-warning e-large text-dark">Add Future Trade</SfButton>
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-warning e-large text-dark">@(IsEditing ? "Update Future Trade" : "Add Future Trade")</SfButton>
         </div>
     </div>
 </div>
 
 @code {
-    [Parameter] public EventCallback OnEntryAdded { get; set; }
+    [Parameter] public EventCallback<int> OnEntryAdded { get; set; }
+    [Parameter] public int? EditingTaxEventId { get; set; }
 
     private DateTime _date = DateTime.Today;
     private string _assetName = string.Empty;
@@ -102,6 +103,8 @@
     private List<CurrencyViewModel> _currencies = [];
     private readonly List<DirectionOption> _directionOptions = [new("Long", "Long"), new("Short", "Short")];
     private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.FUTURE];
+    private int? _loadedEditingTaxEventId;
+    private bool IsEditing => EditingTaxEventId.HasValue;
 
     private decimal ContractValueInGbp => _contractValueAmount * _contractValueFxRate;
     private decimal TotalCostsInGbp => (_commissionAmount * _commissionFxRate) + (_taxAmount * _taxFxRate);
@@ -112,11 +115,30 @@
         _currencies = CurrencyService.GetCurrencies();
     }
 
+    protected override void OnParametersSet()
+    {
+        if (_loadedEditingTaxEventId != EditingTaxEventId)
+        {
+            _loadedEditingTaxEventId = EditingTaxEventId;
+            LoadForEdit();
+        }
+    }
+
     private async Task AddEntry()
     {
         if (!ValidateInputs())
         {
             return;
+        }
+
+        if (EditingTaxEventId.HasValue)
+        {
+            int removed = TaxEventLists.FutureContractTrades.RemoveAll(t => t.Id == EditingTaxEventId.Value);
+            if (removed == 0)
+            {
+                ToastService.ShowError("Unable to update future contract trade because the original entry could not be found.");
+                return;
+            }
         }
 
         List<DescribedMoney> expenses = [];
@@ -149,7 +171,41 @@
         ResetForm();
 
         ToastService.ShowSuccess($"Future contract trade added. Contract value in GBP: {trade.ContractValue.BaseCurrencyAmount}.");
-        await OnEntryAdded.InvokeAsync();
+        await OnEntryAdded.InvokeAsync(trade.Id);
+    }
+
+    private void LoadForEdit()
+    {
+        if (!EditingTaxEventId.HasValue)
+        {
+            return;
+        }
+
+        FutureContractTrade? trade = TaxEventLists.FutureContractTrades.FirstOrDefault(t => t.Id == EditingTaxEventId.Value);
+        if (trade == null)
+        {
+            return;
+        }
+
+        _date = trade.Date;
+        _assetName = trade.AssetName;
+        _direction = trade.PositionType == PositionType.OPENSHORT ? "Short" : "Long";
+        _quantity = trade.Quantity;
+        _contractValueAmount = trade.ContractValue.Amount.Amount;
+        _contractValueCurrency = trade.ContractValue.Amount.Currency;
+        _contractValueFxRate = trade.ContractValue.FxRate;
+
+        DescribedMoney? commission = trade.Expenses.FirstOrDefault(e => string.Equals(e.Description, "Commission", StringComparison.OrdinalIgnoreCase));
+        _commissionAmount = commission?.Amount.Amount ?? 0m;
+        _commissionCurrency = commission?.Amount.Currency ?? "GBP";
+        _commissionFxRate = commission?.FxRate ?? 1m;
+
+        DescribedMoney? tax = trade.Expenses.FirstOrDefault(e => string.Equals(e.Description, "Tax", StringComparison.OrdinalIgnoreCase));
+        _taxAmount = tax?.Amount.Amount ?? 0m;
+        _taxCurrency = tax?.Amount.Currency ?? "GBP";
+        _taxFxRate = tax?.FxRate ?? 1m;
+
+        _description = trade.Description;
     }
 
     private bool ValidateInputs()

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
@@ -20,7 +20,8 @@
                                  DateChanged="@((DateTime value) => _date = value)"
                                  AssetName="@_assetName"
                                  AssetNameChanged="@((string value) => _assetName = value)"
-                                 AssetSuggestions="@_assetSuggestions" />
+                                 AllowManualAssetNameInput="true"
+                                 AssetCategoryFilter="@_assetCategoryFilter" />
 
         <div class="row g-3 mt-1">
             <div class="col-md-4">
@@ -99,8 +100,8 @@
     private string _description = string.Empty;
 
     private List<CurrencyViewModel> _currencies = [];
-    private List<string> _assetSuggestions = [];
     private readonly List<DirectionOption> _directionOptions = [new("Long", "Long"), new("Short", "Short")];
+    private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.FUTURE];
 
     private decimal ContractValueInGbp => _contractValueAmount * _contractValueFxRate;
     private decimal TotalCostsInGbp => (_commissionAmount * _commissionFxRate) + (_taxAmount * _taxFxRate);
@@ -109,7 +110,6 @@
     protected override void OnInitialized()
     {
         _currencies = CurrencyService.GetCurrencies();
-        RefreshAssetSuggestions();
     }
 
     private async Task AddEntry()
@@ -146,7 +146,6 @@
         };
 
         TaxEventLists.FutureContractTrades.Add(trade);
-        RefreshAssetSuggestions();
         ResetForm();
 
         ToastService.ShowSuccess($"Future contract trade added. Contract value in GBP: {trade.ContractValue.BaseCurrencyAmount}.");
@@ -206,16 +205,5 @@
         _taxFxRate = 1m;
         _description = string.Empty;
     }
-
-    private void RefreshAssetSuggestions()
-    {
-        _assetSuggestions = TaxEventLists.AllEvents
-            .Select(i => i.AssetName)
-            .Where(i => !string.IsNullOrWhiteSpace(i))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
     private sealed record DirectionOption(string Value, string Display);
 }

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FutureContractManualEntryForm.razor
@@ -1,0 +1,221 @@
+@using System.Collections.Immutable
+@using InvestmentTaxCalculator.Enumerations
+@using InvestmentTaxCalculator.Model
+@using InvestmentTaxCalculator.Model.TaxEvents
+@using InvestmentTaxCalculator.Services
+@using Syncfusion.Blazor.Buttons
+@using Syncfusion.Blazor.DropDowns
+@using Syncfusion.Blazor.Inputs
+
+@inject TaxEventLists TaxEventLists
+@inject CurrencyService CurrencyService
+@inject ToastService ToastService
+
+<div class="card bg-secondary text-white">
+    <div class="card-header bg-warning text-dark">
+        <h5 class="mb-0">Add Future Contract Trade</h5>
+    </div>
+    <div class="card-body">
+        <ManualEntryCommonFields Date="@_date"
+                                 DateChanged="@((DateTime value) => _date = value)"
+                                 AssetName="@_assetName"
+                                 AssetNameChanged="@((string value) => _assetName = value)"
+                                 AssetSuggestions="@_assetSuggestions" />
+
+        <div class="row g-3 mt-1">
+            <div class="col-md-4">
+                <label class="form-label">Direction</label>
+                <SfDropDownList TValue="string" TItem="DirectionOption" DataSource="@_directionOptions" @bind-Value="@_direction" CssClass="e-outline e-small">
+                    <DropDownListFieldSettings Text="Display" Value="Value"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Quantity (contracts)</label>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="N8" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Description</label>
+                <SfTextBox @bind-Value="@_description" Placeholder="Optional note" FloatLabelType="FloatLabelType.Never"></SfTextBox>
+            </div>
+        </div>
+
+        <AmountCurrencyFxInputRow AmountLabel="Contract Value"
+                                  FxRateLabel="Contract Value FX Rate (to GBP)"
+                                  @bind-Amount="@_contractValueAmount"
+                                  @bind-Currency="@_contractValueCurrency"
+                                  @bind-FxRate="@_contractValueFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-3" />
+
+        <AmountCurrencyFxInputRow AmountLabel="Commission"
+                                  FxRateLabel="Commission FX Rate (to GBP)"
+                                  @bind-Amount="@_commissionAmount"
+                                  @bind-Currency="@_commissionCurrency"
+                                  @bind-FxRate="@_commissionFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-2" />
+
+        <AmountCurrencyFxInputRow AmountLabel="Tax"
+                                  FxRateLabel="Tax FX Rate (to GBP)"
+                                  @bind-Amount="@_taxAmount"
+                                  @bind-Currency="@_taxCurrency"
+                                  @bind-FxRate="@_taxFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-2" />
+
+        @if (CanShowCalculationPreview)
+        {
+            <div class="alert alert-dark border-warning mt-4 mb-0">
+                <div class="row g-2">
+                    <div class="col-md-4"><strong>Contract Value (GBP):</strong> @ContractValueInGbp.ToString("N2")</div>
+                    <div class="col-md-4"><strong>Costs (GBP):</strong> @TotalCostsInGbp.ToString("N2")</div>
+                    <div class="col-md-4"><strong>Immediate Cash Impact (GBP):</strong> @(-TotalCostsInGbp).ToString("N2")</div>
+                </div>
+            </div>
+        }
+
+        <div class="col-12 mt-4 d-flex justify-content-center">
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-warning e-large text-dark">Add Future Trade</SfButton>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback OnEntryAdded { get; set; }
+
+    private DateTime _date = DateTime.Today;
+    private string _assetName = string.Empty;
+    private string _direction = "Long";
+    private decimal _quantity = 1m;
+    private decimal _contractValueAmount;
+    private string _contractValueCurrency = "USD";
+    private decimal _contractValueFxRate = 1m;
+    private decimal _commissionAmount;
+    private string _commissionCurrency = "GBP";
+    private decimal _commissionFxRate = 1m;
+    private decimal _taxAmount;
+    private string _taxCurrency = "GBP";
+    private decimal _taxFxRate = 1m;
+    private string _description = string.Empty;
+
+    private List<CurrencyViewModel> _currencies = [];
+    private List<string> _assetSuggestions = [];
+    private readonly List<DirectionOption> _directionOptions = [new("Long", "Long"), new("Short", "Short")];
+
+    private decimal ContractValueInGbp => _contractValueAmount * _contractValueFxRate;
+    private decimal TotalCostsInGbp => (_commissionAmount * _commissionFxRate) + (_taxAmount * _taxFxRate);
+    private bool CanShowCalculationPreview => _contractValueAmount != 0 && _contractValueFxRate > 0;
+
+    protected override void OnInitialized()
+    {
+        _currencies = CurrencyService.GetCurrencies();
+        RefreshAssetSuggestions();
+    }
+
+    private async Task AddEntry()
+    {
+        if (!ValidateInputs())
+        {
+            return;
+        }
+
+        List<DescribedMoney> expenses = [];
+        if (_commissionAmount != 0)
+        {
+            expenses.Add(new DescribedMoney(_commissionAmount, _commissionCurrency, _commissionFxRate, "Commission"));
+        }
+        if (_taxAmount != 0)
+        {
+            expenses.Add(new DescribedMoney(_taxAmount, _taxCurrency, _taxFxRate, "Tax"));
+        }
+
+        bool isLong = _direction == "Long";
+
+        var trade = new FutureContractTrade
+        {
+            AssetName = _assetName.Trim(),
+            Date = _date,
+            Quantity = _quantity,
+            AcquisitionDisposal = isLong ? TradeType.ACQUISITION : TradeType.DISPOSAL,
+            PositionType = isLong ? PositionType.OPENLONG : PositionType.OPENSHORT,
+            AssetType = AssetCategoryType.FUTURE,
+            GrossProceed = new DescribedMoney(0m, "GBP", 1m, "Future gross proceed is set to 0"),
+            ContractValue = new DescribedMoney(_contractValueAmount, _contractValueCurrency, _contractValueFxRate, "Contract value"),
+            Expenses = expenses.ToImmutableList(),
+            Description = _description.Trim()
+        };
+
+        TaxEventLists.FutureContractTrades.Add(trade);
+        RefreshAssetSuggestions();
+        ResetForm();
+
+        ToastService.ShowSuccess($"Future contract trade added. Contract value in GBP: {trade.ContractValue.BaseCurrencyAmount}.");
+        await OnEntryAdded.InvokeAsync();
+    }
+
+    private bool ValidateInputs()
+    {
+        if (string.IsNullOrWhiteSpace(_assetName))
+        {
+            ToastService.ShowError("Asset name is required.");
+            return false;
+        }
+
+        if (_quantity <= 0)
+        {
+            ToastService.ShowError("Quantity must be greater than 0.");
+            return false;
+        }
+
+        if (_contractValueAmount == 0)
+        {
+            ToastService.ShowError("Contract value cannot be 0.");
+            return false;
+        }
+
+        if (_contractValueFxRate <= 0)
+        {
+            ToastService.ShowError("Contract value FX rate must be greater than 0.");
+            return false;
+        }
+
+        if (_commissionAmount != 0 && _commissionFxRate <= 0)
+        {
+            ToastService.ShowError("Commission FX rate must be greater than 0.");
+            return false;
+        }
+
+        if (_taxAmount != 0 && _taxFxRate <= 0)
+        {
+            ToastService.ShowError("Tax FX rate must be greater than 0.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void ResetForm()
+    {
+        _assetName = string.Empty;
+        _quantity = 1m;
+        _contractValueAmount = 0m;
+        _contractValueFxRate = 1m;
+        _commissionAmount = 0m;
+        _commissionFxRate = 1m;
+        _taxAmount = 0m;
+        _taxFxRate = 1m;
+        _description = string.Empty;
+    }
+
+    private void RefreshAssetSuggestions()
+    {
+        _assetSuggestions = TaxEventLists.AllEvents
+            .Select(i => i.AssetName)
+            .Where(i => !string.IsNullOrWhiteSpace(i))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private sealed record DirectionOption(string Value, string Display);
+}

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FxTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FxTradeManualEntryForm.razor
@@ -129,7 +129,7 @@
         if (EditingTaxEventId.HasValue)
         {
             int removed = TaxEventLists.Trades.RemoveAll(t => t.Id == EditingTaxEventId.Value && t.AssetType == AssetCategoryType.FX);
-            if (removed == 0)
+            if (removed != 1)
             {
                 ToastService.ShowError("Unable to update FX trade because the original entry could not be found.");
                 return;

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FxTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FxTradeManualEntryForm.razor
@@ -1,0 +1,186 @@
+@using System.Collections.Immutable
+@using InvestmentTaxCalculator.Enumerations
+@using InvestmentTaxCalculator.Model
+@using InvestmentTaxCalculator.Model.TaxEvents
+@using InvestmentTaxCalculator.Services
+@using Syncfusion.Blazor.Buttons
+@using Syncfusion.Blazor.Calendars
+@using Syncfusion.Blazor.DropDowns
+@using Syncfusion.Blazor.Inputs
+
+@inject TaxEventLists TaxEventLists
+@inject CurrencyService CurrencyService
+@inject ToastService ToastService
+
+<div class="card bg-secondary text-white">
+    <div class="card-header bg-info text-dark">
+        <h5 class="mb-0">Add FX Trade</h5>
+    </div>
+    <div class="card-body">
+        <div class="row g-3">
+            <div class="col-md-3">
+                <label class="form-label">Date</label>
+                <SfDatePicker TValue="DateTime" @bind-Value="@_date" Format="d" CssClass="e-outline e-small"></SfDatePicker>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">FX Asset Name</label>
+                <SfDropDownList TValue="string" TItem="CurrencyViewModel" DataSource="@_currencies" @bind-Value="@_assetCurrency" CssClass="e-outline e-small" PopupHeight="260px">
+                    <DropDownListFieldSettings Text="Code" Value="Code"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Trade Type</label>
+                <SfDropDownList TValue="TradeType" TItem="EnumDescriptionPair<TradeType>" DataSource="@_tradeTypes" @bind-Value="@_tradeType" CssClass="e-outline e-small">
+                    <DropDownListFieldSettings Text="Description" Value="EnumValue"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Quantity</label>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="N8" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Description</label>
+                <SfTextBox @bind-Value="@_description" Placeholder="Optional note" FloatLabelType="FloatLabelType.Never"></SfTextBox>
+            </div>
+        </div>
+
+        <AmountCurrencyFxInputRow AmountLabel="Gross Proceed"
+                                  FxRateLabel="FX Rate (to GBP)"
+                                  @bind-Amount="@_grossProceedAmount"
+                                  @bind-Currency="@_assetCurrency"
+                                  @bind-FxRate="@_grossProceedFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-3" />
+
+        <AmountCurrencyFxInputRow AmountLabel="Commission"
+                                  FxRateLabel="Commission FX Rate (to GBP)"
+                                  @bind-Amount="@_commissionAmount"
+                                  @bind-Currency="@_commissionCurrency"
+                                  @bind-FxRate="@_commissionFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-2" />
+
+        @if (CanShowCalculationPreview)
+        {
+            <div class="alert alert-dark border-info mt-4 mb-0">
+                <div class="row g-2">
+                    <div class="col-md-4"><strong>Gross (GBP):</strong> @GrossProceedInGbp.ToString("N2")</div>
+                    <div class="col-md-4"><strong>Commission (GBP):</strong> @CommissionInGbp.ToString("N2")</div>
+                    <div class="col-md-4"><strong>Estimated Net (GBP):</strong> @EstimatedNetProceedInGbp.ToString("N2")</div>
+                </div>
+            </div>
+        }
+
+        <div class="col-12 mt-4 d-flex justify-content-center">
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-info e-large text-dark">Add FX Trade</SfButton>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback OnEntryAdded { get; set; }
+
+    private DateTime _date = DateTime.Today;
+    private string _assetCurrency = "USD";
+    private TradeType _tradeType = TradeType.ACQUISITION;
+    private decimal _quantity = 1m;
+    private decimal _grossProceedAmount;
+    private decimal _grossProceedFxRate = 1m;
+    private decimal _commissionAmount;
+    private string _commissionCurrency = "GBP";
+    private decimal _commissionFxRate = 1m;
+    private string _description = string.Empty;
+
+    private List<CurrencyViewModel> _currencies = [];
+    private List<EnumDescriptionPair<TradeType>> _tradeTypes = [];
+
+    private decimal GrossProceedInGbp => _grossProceedAmount * _grossProceedFxRate;
+    private decimal CommissionInGbp => _commissionAmount * _commissionFxRate;
+    private decimal EstimatedNetProceedInGbp => _tradeType == TradeType.ACQUISITION
+        ? GrossProceedInGbp + CommissionInGbp
+        : GrossProceedInGbp - CommissionInGbp;
+    private bool CanShowCalculationPreview => _grossProceedAmount > 0 && _grossProceedFxRate > 0;
+
+    protected override void OnInitialized()
+    {
+        _currencies = CurrencyService.GetCurrencies();
+        _tradeTypes = EnumExtensions.GetEnumDescriptionPair<TradeType>(typeof(TradeType));
+    }
+
+    private async Task AddEntry()
+    {
+        if (!ValidateInputs())
+        {
+            return;
+        }
+
+        List<DescribedMoney> expenses = [];
+        if (_commissionAmount != 0)
+        {
+            expenses.Add(new DescribedMoney(_commissionAmount, _commissionCurrency, _commissionFxRate, "Commission"));
+        }
+
+        var trade = new FxTrade
+        {
+            AssetName = _assetCurrency,
+            Date = _date,
+            Quantity = _quantity,
+            AcquisitionDisposal = _tradeType,
+            AssetType = AssetCategoryType.FX,
+            GrossProceed = new DescribedMoney(_grossProceedAmount, _assetCurrency, _grossProceedFxRate, "FX gross proceed"),
+            Expenses = expenses.ToImmutableList(),
+            Description = _description.Trim()
+        };
+
+        TaxEventLists.Trades.Add(trade);
+        ResetForm();
+
+        ToastService.ShowSuccess($"FX trade added. Estimated net amount: {trade.NetProceed}.");
+        await OnEntryAdded.InvokeAsync();
+    }
+
+    private bool ValidateInputs()
+    {
+        if (string.IsNullOrWhiteSpace(_assetCurrency))
+        {
+            ToastService.ShowError("FX asset currency is required.");
+            return false;
+        }
+
+        if (_quantity <= 0)
+        {
+            ToastService.ShowError("Quantity must be greater than 0.");
+            return false;
+        }
+
+        if (_grossProceedAmount <= 0)
+        {
+            ToastService.ShowError("Gross proceed must be greater than 0.");
+            return false;
+        }
+
+        if (_grossProceedFxRate <= 0)
+        {
+            ToastService.ShowError("FX rate must be greater than 0.");
+            return false;
+        }
+
+        if (_commissionAmount != 0 && _commissionFxRate <= 0)
+        {
+            ToastService.ShowError("Commission FX rate must be greater than 0.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void ResetForm()
+    {
+        _quantity = 1m;
+        _grossProceedAmount = 0m;
+        _grossProceedFxRate = 1m;
+        _commissionAmount = 0m;
+        _commissionFxRate = 1m;
+        _description = string.Empty;
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FxTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FxTradeManualEntryForm.razor
@@ -14,7 +14,7 @@
 
 <div class="card bg-secondary text-white">
     <div class="card-header bg-info text-dark">
-        <h5 class="mb-0">Add FX Trade</h5>
+        <h5 class="mb-0">@(IsEditing ? "Edit FX Trade" : "Add FX Trade")</h5>
     </div>
     <div class="card-body">
         <div class="row g-3">
@@ -66,19 +66,20 @@
                 <div class="row g-2">
                     <div class="col-md-4"><strong>Gross (GBP):</strong> @GrossProceedInGbp.ToString("N2")</div>
                     <div class="col-md-4"><strong>Commission (GBP):</strong> @CommissionInGbp.ToString("N2")</div>
-                    <div class="col-md-4"><strong>Estimated Net (GBP):</strong> @EstimatedNetProceedInGbp.ToString("N2")</div>
+                    <div class="col-md-4"><strong>Net (GBP):</strong> @NetProceedInGbp.ToString("N2")</div>
                 </div>
             </div>
         }
 
         <div class="col-12 mt-4 d-flex justify-content-center">
-            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-info e-large text-dark">Add FX Trade</SfButton>
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-info e-large text-dark">@(IsEditing ? "Update FX Trade" : "Add FX Trade")</SfButton>
         </div>
     </div>
 </div>
 
 @code {
-    [Parameter] public EventCallback OnEntryAdded { get; set; }
+    [Parameter] public EventCallback<int> OnEntryAdded { get; set; }
+    [Parameter] public int? EditingTaxEventId { get; set; }
 
     private DateTime _date = DateTime.Today;
     private string _assetCurrency = "USD";
@@ -93,10 +94,12 @@
 
     private List<CurrencyViewModel> _currencies = [];
     private List<EnumDescriptionPair<TradeType>> _tradeTypes = [];
+    private int? _loadedEditingTaxEventId;
+    private bool IsEditing => EditingTaxEventId.HasValue;
 
     private decimal GrossProceedInGbp => _grossProceedAmount * _grossProceedFxRate;
     private decimal CommissionInGbp => _commissionAmount * _commissionFxRate;
-    private decimal EstimatedNetProceedInGbp => _tradeType == TradeType.ACQUISITION
+    private decimal NetProceedInGbp => _tradeType == TradeType.ACQUISITION
         ? GrossProceedInGbp + CommissionInGbp
         : GrossProceedInGbp - CommissionInGbp;
     private bool CanShowCalculationPreview => _grossProceedAmount > 0 && _grossProceedFxRate > 0;
@@ -107,11 +110,30 @@
         _tradeTypes = EnumExtensions.GetEnumDescriptionPair<TradeType>(typeof(TradeType));
     }
 
+    protected override void OnParametersSet()
+    {
+        if (_loadedEditingTaxEventId != EditingTaxEventId)
+        {
+            _loadedEditingTaxEventId = EditingTaxEventId;
+            LoadForEdit();
+        }
+    }
+
     private async Task AddEntry()
     {
         if (!ValidateInputs())
         {
             return;
+        }
+
+        if (EditingTaxEventId.HasValue)
+        {
+            int removed = TaxEventLists.Trades.RemoveAll(t => t.Id == EditingTaxEventId.Value && t.AssetType == AssetCategoryType.FX);
+            if (removed == 0)
+            {
+                ToastService.ShowError("Unable to update FX trade because the original entry could not be found.");
+                return;
+            }
         }
 
         List<DescribedMoney> expenses = [];
@@ -135,8 +157,38 @@
         TaxEventLists.Trades.Add(trade);
         ResetForm();
 
-        ToastService.ShowSuccess($"FX trade added. Estimated net amount: {trade.NetProceed}.");
-        await OnEntryAdded.InvokeAsync();
+        ToastService.ShowSuccess($"FX trade added. Net amount: {trade.NetProceed}.");
+        await OnEntryAdded.InvokeAsync(trade.Id);
+    }
+
+    private void LoadForEdit()
+    {
+        if (!EditingTaxEventId.HasValue)
+        {
+            return;
+        }
+
+        FxTrade? trade = TaxEventLists.Trades
+            .OfType<FxTrade>()
+            .FirstOrDefault(t => t.Id == EditingTaxEventId.Value);
+
+        if (trade == null)
+        {
+            return;
+        }
+
+        _date = trade.Date;
+        _assetCurrency = trade.AssetName;
+        _tradeType = trade.AcquisitionDisposal;
+        _quantity = trade.Quantity;
+        _grossProceedAmount = trade.GrossProceed.Amount.Amount;
+        _grossProceedFxRate = trade.GrossProceed.FxRate;
+
+        DescribedMoney? commission = trade.Expenses.FirstOrDefault(e => string.Equals(e.Description, "Commission", StringComparison.OrdinalIgnoreCase));
+        _commissionAmount = commission?.Amount.Amount ?? 0m;
+        _commissionCurrency = commission?.Amount.Currency ?? "GBP";
+        _commissionFxRate = commission?.FxRate ?? 1m;
+        _description = trade.Description;
     }
 
     private bool ValidateInputs()

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FxTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FxTradeManualEntryForm.razor
@@ -36,7 +36,7 @@
             </div>
             <div class="col-md-3">
                 <label class="form-label">Quantity</label>
-                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="N8" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="0.########" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
             </div>
             <div class="col-md-6">
                 <label class="form-label">Description</label>
@@ -235,4 +235,5 @@
         _commissionFxRate = 1m;
         _description = string.Empty;
     }
+
 }

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FxTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/FxTradeManualEntryForm.razor
@@ -157,7 +157,8 @@
         TaxEventLists.Trades.Add(trade);
         ResetForm();
 
-        ToastService.ShowSuccess($"FX trade added. Net amount: {trade.NetProceed}.");
+        string verb = IsEditing ? "updated" : "added";
+        ToastService.ShowSuccess($"FX trade {verb}. Net amount: {trade.NetProceed}.");
         await OnEntryAdded.InvokeAsync(trade.Id);
     }
 

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
@@ -12,7 +12,7 @@
 
 <div class="card bg-secondary text-white">
     <div class="card-header bg-primary text-white">
-        <h5 class="mb-0">Add Interest Income</h5>
+        <h5 class="mb-0">@(IsEditing ? "Edit Interest Income" : "Add Interest Income")</h5>
     </div>
     <div class="card-body">
         <ManualEntryCommonFields Date="@_date"
@@ -78,13 +78,14 @@
         }
 
         <div class="col-12 mt-4 d-flex justify-content-center">
-            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-primary e-large">Add Interest Income</SfButton>
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-primary e-large">@(IsEditing ? "Update Interest Income" : "Add Interest Income")</SfButton>
         </div>
     </div>
 </div>
 
 @code {
-    [Parameter] public EventCallback OnEntryAdded { get; set; }
+    [Parameter] public EventCallback<int> OnEntryAdded { get; set; }
+    [Parameter] public int? EditingTaxEventId { get; set; }
 
     private DateTime _date = DateTime.Today;
     private string _assetName = string.Empty;
@@ -101,6 +102,8 @@
     private List<EnumDescriptionPair<InterestType>> _interestTypes = [];
     private List<CountryCodeOption> _countryCodes = [];
     private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.STOCK];
+    private int? _loadedEditingTaxEventId;
+    private bool IsEditing => EditingTaxEventId.HasValue;
 
     private bool IsAccruedIncomeType => _interestType is InterestType.ACCURREDINCOMEPROFIT or InterestType.ACCURREDINCOMELOSS;
     private bool IsTaxDeferred => IsAccruedIncomeType && !_isNextPaymentInSameTaxYear;
@@ -118,11 +121,30 @@
             .ToList();
     }
 
+    protected override void OnParametersSet()
+    {
+        if (_loadedEditingTaxEventId != EditingTaxEventId)
+        {
+            _loadedEditingTaxEventId = EditingTaxEventId;
+            LoadForEdit();
+        }
+    }
+
     private async Task AddEntry()
     {
         if (!ValidateInputs(out CountryCode countryCode))
         {
             return;
+        }
+
+        if (EditingTaxEventId.HasValue)
+        {
+            int removed = TaxEventLists.InterestIncomes.RemoveAll(i => i.Id == EditingTaxEventId.Value);
+            if (removed == 0)
+            {
+                ToastService.ShowError("Unable to update interest income because the original entry could not be found.");
+                return;
+            }
         }
 
         var interestIncome = new InterestIncome
@@ -140,7 +162,32 @@
         ResetForm();
 
         ToastService.ShowSuccess($"Interest income added. Amount in GBP: {interestIncome.Amount.BaseCurrencyAmount}.");
-        await OnEntryAdded.InvokeAsync();
+        await OnEntryAdded.InvokeAsync(interestIncome.Id);
+    }
+
+    private void LoadForEdit()
+    {
+        if (!EditingTaxEventId.HasValue)
+        {
+            return;
+        }
+
+        InterestIncome? interestIncome = TaxEventLists.InterestIncomes.FirstOrDefault(i => i.Id == EditingTaxEventId.Value);
+        if (interestIncome == null)
+        {
+            return;
+        }
+
+        _date = interestIncome.Date;
+        _assetName = interestIncome.AssetName;
+        _interestType = interestIncome.InterestType;
+        _amount = interestIncome.Amount.Amount.Amount;
+        _currency = interestIncome.Amount.Amount.Currency;
+        _fxRate = interestIncome.Amount.FxRate;
+        _incomeLocationCode = interestIncome.IncomeLocation.ThreeDigitCode;
+        _isin = interestIncome.Isin;
+        _isNextPaymentInSameTaxYear = interestIncome.IsNextPaymentInSameTaxYear;
+        _description = interestIncome.Amount.Description;
     }
 
     private bool ValidateInputs(out CountryCode countryCode)

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
@@ -19,7 +19,8 @@
                                  DateChanged="@((DateTime value) => _date = value)"
                                  AssetName="@_assetName"
                                  AssetNameChanged="@((string value) => _assetName = value)"
-                                 AssetSuggestions="@_assetSuggestions" />
+                                 AllowManualAssetNameInput="true"
+                                 AssetCategoryFilter="@_assetCategoryFilter" />
 
         <div class="row g-3 mt-1">
             <div class="col-md-4">
@@ -97,9 +98,9 @@
     private string _description = string.Empty;
 
     private List<CurrencyViewModel> _currencies = [];
-    private List<string> _assetSuggestions = [];
     private List<EnumDescriptionPair<InterestType>> _interestTypes = [];
     private List<CountryCodeOption> _countryCodes = [];
+    private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.STOCK];
 
     private bool IsAccruedIncomeType => _interestType is InterestType.ACCURREDINCOMEPROFIT or InterestType.ACCURREDINCOMELOSS;
     private bool IsTaxDeferred => IsAccruedIncomeType && !_isNextPaymentInSameTaxYear;
@@ -115,7 +116,6 @@
         _countryCodes = CountryCode.GetAllRegions()
             .Select(c => new CountryCodeOption(c.ThreeDigitCode, c.CountryName))
             .ToList();
-        RefreshAssetSuggestions();
     }
 
     private async Task AddEntry()
@@ -137,7 +137,6 @@
         };
 
         TaxEventLists.InterestIncomes.Add(interestIncome);
-        RefreshAssetSuggestions();
         ResetForm();
 
         ToastService.ShowSuccess($"Interest income added. Amount in GBP: {interestIncome.Amount.BaseCurrencyAmount}.");
@@ -206,17 +205,6 @@
         _isNextPaymentInSameTaxYear = true;
         _description = string.Empty;
     }
-
-    private void RefreshAssetSuggestions()
-    {
-        _assetSuggestions = TaxEventLists.AllEvents
-            .Select(i => i.AssetName)
-            .Where(i => !string.IsNullOrWhiteSpace(i))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
     private sealed record CountryCodeOption(string ThreeDigitCode, string CountryName)
     {
         public string Display => $"{ThreeDigitCode} - {CountryName}";

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
@@ -252,6 +252,7 @@
         _isNextPaymentInSameTaxYear = true;
         _description = string.Empty;
     }
+
     private sealed record CountryCodeOption(string ThreeDigitCode, string CountryName)
     {
         public string Display => $"{ThreeDigitCode} - {CountryName}";

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
@@ -139,12 +139,15 @@
 
         if (EditingTaxEventId.HasValue)
         {
-            int removed = TaxEventLists.InterestIncomes.RemoveAll(i => i.Id == EditingTaxEventId.Value);
-            if (removed == 0)
+            int matches = TaxEventLists.InterestIncomes.Count(i => i.Id == EditingTaxEventId.Value);
+            if (matches != 1)
             {
                 ToastService.ShowError("Unable to update interest income because the original entry could not be found.");
                 return;
             }
+
+            int index = TaxEventLists.InterestIncomes.FindIndex(i => i.Id == EditingTaxEventId.Value);
+            TaxEventLists.InterestIncomes.RemoveAt(index);
         }
 
         var interestIncome = new InterestIncome

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
@@ -161,7 +161,8 @@
         TaxEventLists.InterestIncomes.Add(interestIncome);
         ResetForm();
 
-        ToastService.ShowSuccess($"Interest income added. Amount in GBP: {interestIncome.Amount.BaseCurrencyAmount}.");
+        string verb = IsEditing ? "updated" : "added";
+        ToastService.ShowSuccess($"Interest income {verb}. Amount in GBP: {interestIncome.Amount.BaseCurrencyAmount}.");
         await OnEntryAdded.InvokeAsync(interestIncome.Id);
     }
 

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
@@ -104,7 +104,7 @@
     private bool IsAccruedIncomeType => _interestType is InterestType.ACCURREDINCOMEPROFIT or InterestType.ACCURREDINCOMELOSS;
     private bool IsTaxDeferred => IsAccruedIncomeType && !_isNextPaymentInSameTaxYear;
     private decimal AmountInGbp => _amount * _fxRate;
-    private bool CanShowCalculationPreview => _amount != 0 && _fxRate > 0;
+    private bool CanShowCalculationPreview => IsAmountValidForSelectedType(showToast: false) && _fxRate > 0;
 
     protected override void OnInitialized()
     {
@@ -154,11 +154,7 @@
             return false;
         }
 
-        if (_amount == 0)
-        {
-            ToastService.ShowError("Amount cannot be 0.");
-            return false;
-        }
+        if (!IsAmountValidForSelectedType(showToast: true)) return false;
 
         if (_fxRate <= 0)
         {
@@ -169,6 +165,35 @@
         countryCode = CountryCode.GetRegionByThreeDigitCode(_incomeLocationCode);
 
         return true;
+    }
+
+    private bool IsAmountValidForSelectedType(bool showToast)
+    {
+        if (_interestType == InterestType.ACCURREDINCOMEPROFIT)
+        {
+            return _amount > 0
+                || FailAmountValidation("Accrued income profit amount must be greater than 0.", showToast);
+        }
+
+        if (_interestType == InterestType.ACCURREDINCOMELOSS)
+        {
+            // Loss entries are represented by negative amounts.
+            return _amount < 0
+                || FailAmountValidation("Accrued income loss amount must be less than 0.", showToast);
+        }
+
+        return _amount > 0
+            || FailAmountValidation($"{_interestType.GetDescription()} amount must be greater than 0.", showToast);
+    }
+
+    private bool FailAmountValidation(string errorMessage, bool showToast)
+    {
+        if (showToast)
+        {
+            ToastService.ShowError(errorMessage);
+        }
+
+        return false;
     }
 
     private void ResetForm()

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
@@ -1,0 +1,199 @@
+@using InvestmentTaxCalculator.Enumerations
+@using InvestmentTaxCalculator.Model
+@using InvestmentTaxCalculator.Model.TaxEvents
+@using InvestmentTaxCalculator.Services
+@using Syncfusion.Blazor.Buttons
+@using Syncfusion.Blazor.DropDowns
+@using Syncfusion.Blazor.Inputs
+
+@inject TaxEventLists TaxEventLists
+@inject CurrencyService CurrencyService
+@inject ToastService ToastService
+
+<div class="card bg-secondary text-white">
+    <div class="card-header bg-primary text-white">
+        <h5 class="mb-0">Add Interest Income</h5>
+    </div>
+    <div class="card-body">
+        <ManualEntryCommonFields Date="@_date"
+                                 DateChanged="@((DateTime value) => _date = value)"
+                                 AssetName="@_assetName"
+                                 AssetNameChanged="@((string value) => _assetName = value)"
+                                 AssetSuggestions="@_assetSuggestions" />
+
+        <div class="row g-3 mt-1">
+            <div class="col-md-4">
+                <label class="form-label">Interest Type</label>
+                <SfDropDownList TValue="InterestType" TItem="EnumDescriptionPair<InterestType>" DataSource="@_interestTypes" @bind-Value="@_interestType" CssClass="e-outline e-small">
+                    <DropDownListFieldSettings Text="Description" Value="EnumValue"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Income Location</label>
+                <SfDropDownList TValue="string" TItem="CountryCodeOption" DataSource="@_countryCodes" @bind-Value="@_incomeLocationCode" CssClass="e-outline e-small" PopupHeight="260px" AllowFiltering="true" Placeholder="Select country">
+                    <DropDownListFieldSettings Text="Display" Value="ThreeDigitCode"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">ISIN (optional)</label>
+                <SfTextBox @bind-Value="@_isin" Placeholder="Optional ISIN" FloatLabelType="FloatLabelType.Never"></SfTextBox>
+            </div>
+
+            @if (IsAccruedIncomeType)
+            {
+                <div class="col-md-6 d-flex align-items-center">
+                    <div class="form-check mt-4">
+                        <input class="form-check-input" type="checkbox" id="sameTaxYearCheckbox" @bind="_isNextPaymentInSameTaxYear" />
+                        <label class="form-check-label" for="sameTaxYearCheckbox">
+                            Next payment is in the same UK tax year
+                        </label>
+                    </div>
+                </div>
+            }
+
+            <div class="col-md-8">
+                <label class="form-label">Description</label>
+                <SfTextBox @bind-Value="@_description" Placeholder="Optional note" FloatLabelType="FloatLabelType.Never"></SfTextBox>
+            </div>
+        </div>
+
+        <AmountCurrencyFxInputRow AmountLabel="Amount"
+                                  FxRateLabel="FX Rate (to GBP)"
+                                  @bind-Amount="@_amount"
+                                  @bind-Currency="@_currency"
+                                  @bind-FxRate="@_fxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-3" />
+
+        @if (CanShowCalculationPreview)
+        {
+            <div class="alert alert-dark border-primary mt-4 mb-0">
+                <div class="row g-2">
+                    <div class="col-md-4"><strong>Amount (GBP):</strong> @AmountInGbp.ToString("N2")</div>
+                    <div class="col-md-4"><strong>Tax Deferred:</strong> @(IsTaxDeferred ? "Yes" : "No")</div>
+                    <div class="col-md-4"><strong>Type:</strong> @_interestType.GetDescription()</div>
+                </div>
+            </div>
+        }
+
+        <div class="col-12 mt-4 d-flex justify-content-center">
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-primary e-large">Add Interest Income</SfButton>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback OnEntryAdded { get; set; }
+
+    private DateTime _date = DateTime.Today;
+    private string _assetName = string.Empty;
+    private InterestType _interestType = InterestType.SAVINGS;
+    private decimal _amount;
+    private string _currency = "GBP";
+    private decimal _fxRate = 1m;
+    private string _incomeLocationCode = CountryCode.UnknownRegion.ThreeDigitCode;
+    private string _isin = string.Empty;
+    private bool _isNextPaymentInSameTaxYear = true;
+    private string _description = string.Empty;
+
+    private List<CurrencyViewModel> _currencies = [];
+    private List<string> _assetSuggestions = [];
+    private List<EnumDescriptionPair<InterestType>> _interestTypes = [];
+    private List<CountryCodeOption> _countryCodes = [];
+
+    private bool IsAccruedIncomeType => _interestType is InterestType.ACCURREDINCOMEPROFIT or InterestType.ACCURREDINCOMELOSS;
+    private bool IsTaxDeferred => IsAccruedIncomeType && !_isNextPaymentInSameTaxYear;
+    private decimal AmountInGbp => _amount * _fxRate;
+    private bool CanShowCalculationPreview => _amount != 0 && _fxRate > 0;
+
+    protected override void OnInitialized()
+    {
+        _currencies = CurrencyService.GetCurrencies();
+        _interestTypes = EnumExtensions.GetEnumDescriptionPair<InterestType>(typeof(InterestType))
+            .Where(i => i.EnumValue != InterestType.EXCESSREPORTABLEINCOME)
+            .ToList();
+        _countryCodes = CountryCode.GetAllRegions()
+            .Select(c => new CountryCodeOption(c.ThreeDigitCode, c.CountryName))
+            .ToList();
+        RefreshAssetSuggestions();
+    }
+
+    private async Task AddEntry()
+    {
+        if (!ValidateInputs(out CountryCode countryCode))
+        {
+            return;
+        }
+
+        var interestIncome = new InterestIncome
+        {
+            AssetName = _assetName.Trim(),
+            Date = _date,
+            InterestType = _interestType,
+            IncomeLocation = countryCode,
+            Isin = _isin.Trim(),
+            IsNextPaymentInSameTaxYear = _isNextPaymentInSameTaxYear,
+            Amount = new DescribedMoney(_amount, _currency, _fxRate, _description.Trim())
+        };
+
+        TaxEventLists.InterestIncomes.Add(interestIncome);
+        RefreshAssetSuggestions();
+        ResetForm();
+
+        ToastService.ShowSuccess($"Interest income added. Amount in GBP: {interestIncome.Amount.BaseCurrencyAmount}.");
+        await OnEntryAdded.InvokeAsync();
+    }
+
+    private bool ValidateInputs(out CountryCode countryCode)
+    {
+        countryCode = CountryCode.UnknownRegion;
+
+        if (string.IsNullOrWhiteSpace(_assetName))
+        {
+            ToastService.ShowError("Asset name is required.");
+            return false;
+        }
+
+        if (_amount == 0)
+        {
+            ToastService.ShowError("Amount cannot be 0.");
+            return false;
+        }
+
+        if (_fxRate <= 0)
+        {
+            ToastService.ShowError("FX rate must be greater than 0.");
+            return false;
+        }
+
+        countryCode = CountryCode.GetRegionByThreeDigitCode(_incomeLocationCode);
+
+        return true;
+    }
+
+    private void ResetForm()
+    {
+        _assetName = string.Empty;
+        _amount = 0m;
+        _fxRate = 1m;
+        _incomeLocationCode = CountryCode.UnknownRegion.ThreeDigitCode;
+        _isin = string.Empty;
+        _isNextPaymentInSameTaxYear = true;
+        _description = string.Empty;
+    }
+
+    private void RefreshAssetSuggestions()
+    {
+        _assetSuggestions = TaxEventLists.AllEvents
+            .Select(i => i.AssetName)
+            .Where(i => !string.IsNullOrWhiteSpace(i))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private sealed record CountryCodeOption(string ThreeDigitCode, string CountryName)
+    {
+        public string Display => $"{ThreeDigitCode} - {CountryName}";
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/ManualEntryCommonFields.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/ManualEntryCommonFields.razor
@@ -1,5 +1,7 @@
 @using Syncfusion.Blazor.Calendars
 @using Syncfusion.Blazor.DropDowns
+@using InvestmentTaxCalculator.Components
+@using InvestmentTaxCalculator.Enumerations
 
 <div class="row g-3">
     <div class="col-md-4">
@@ -14,15 +16,12 @@
     </div>
     <div class="col-md-8">
         <label class="form-label">@AssetLabel</label>
-        <SfComboBox TValue="string"
-                    TItem="string"
-                    DataSource="@AssetSuggestions"
-                    Value="@AssetName"
-                    AllowCustom="true"
-                    Placeholder="@AssetPlaceholder"
-                    CssClass="e-outline">
-            <ComboBoxEvents TValue="string" TItem="string" ValueChange="@HandleAssetChange" />
-        </SfComboBox>
+        <AssetNameSelector Value="@AssetName"
+                           ValueChanged="@AssetNameChanged"
+                           AllowManualAssetNameInput="@AllowManualAssetNameInput"
+                           AssetCategoryFilter="@AssetCategoryFilter"
+                           Placeholder="@AssetPlaceholder"
+                           CssClass="e-outline" />
     </div>
 </div>
 
@@ -37,15 +36,11 @@
     [Parameter] public string DatePlaceholder { get; set; } = "Select date";
     [Parameter] public string AssetLabel { get; set; } = "Asset / Ticker";
     [Parameter] public string AssetPlaceholder { get; set; } = "Enter ticker or asset name";
-    [Parameter] public IReadOnlyList<string> AssetSuggestions { get; set; } = [];
+    [Parameter] public bool AllowManualAssetNameInput { get; set; } = true;
+    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [];
 
     private async Task HandleDateChange(Syncfusion.Blazor.Calendars.ChangedEventArgs<DateTime> args)
     {
         await DateChanged.InvokeAsync(args.Value);
-    }
-
-    private async Task HandleAssetChange(Syncfusion.Blazor.DropDowns.ChangeEventArgs<string, string> args)
-    {
-        await AssetNameChanged.InvokeAsync(args.Value ?? string.Empty);
     }
 }

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/ManualEntryCommonFields.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/ManualEntryCommonFields.razor
@@ -1,0 +1,51 @@
+@using Syncfusion.Blazor.Calendars
+@using Syncfusion.Blazor.DropDowns
+
+<div class="row g-3">
+    <div class="col-md-4">
+        <label class="form-label">@DateLabel</label>
+        <SfDatePicker TValue="DateTime"
+                      Value="@Date"
+                      Format="d"
+                      Placeholder="@DatePlaceholder"
+                      CssClass="e-outline">
+            <DatePickerEvents TValue="DateTime" ValueChange="@HandleDateChange" />
+        </SfDatePicker>
+    </div>
+    <div class="col-md-8">
+        <label class="form-label">@AssetLabel</label>
+        <SfComboBox TValue="string"
+                    TItem="string"
+                    DataSource="@AssetSuggestions"
+                    Value="@AssetName"
+                    AllowCustom="true"
+                    Placeholder="@AssetPlaceholder"
+                    CssClass="e-outline">
+            <ComboBoxEvents TValue="string" TItem="string" ValueChange="@HandleAssetChange" />
+        </SfComboBox>
+    </div>
+</div>
+
+@code {
+    [Parameter] public DateTime Date { get; set; } = DateTime.Today;
+    [Parameter] public EventCallback<DateTime> DateChanged { get; set; }
+
+    [Parameter] public string AssetName { get; set; } = string.Empty;
+    [Parameter] public EventCallback<string> AssetNameChanged { get; set; }
+
+    [Parameter] public string DateLabel { get; set; } = "Date";
+    [Parameter] public string DatePlaceholder { get; set; } = "Select date";
+    [Parameter] public string AssetLabel { get; set; } = "Asset / Ticker";
+    [Parameter] public string AssetPlaceholder { get; set; } = "Enter ticker or asset name";
+    [Parameter] public IReadOnlyList<string> AssetSuggestions { get; set; } = [];
+
+    private async Task HandleDateChange(Syncfusion.Blazor.Calendars.ChangedEventArgs<DateTime> args)
+    {
+        await DateChanged.InvokeAsync(args.Value);
+    }
+
+    private async Task HandleAssetChange(Syncfusion.Blazor.DropDowns.ChangeEventArgs<string, string> args)
+    {
+        await AssetNameChanged.InvokeAsync(args.Value ?? string.Empty);
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
@@ -14,7 +14,7 @@
 
 <div class="card bg-secondary text-white">
     <div class="card-header bg-success text-white">
-        <h5 class="mb-0">Add Option Trade</h5>
+        <h5 class="mb-0">@(IsEditing ? "Edit Option Trade" : "Add Option Trade")</h5>
     </div>
     <div class="card-body">
         <ManualEntryCommonFields Date="@_date"
@@ -110,20 +110,21 @@
                 <div class="row g-2">
                     <div class="col-md-3"><strong>Premium (GBP):</strong> @PremiumInGbp.ToString("N2")</div>
                     <div class="col-md-3"><strong>Costs (GBP):</strong> @TotalCostsInGbp.ToString("N2")</div>
-                    <div class="col-md-3"><strong>Net Premium (GBP):</strong> @EstimatedNetPremiumInGbp.ToString("N2")</div>
+                    <div class="col-md-3"><strong>Net Premium (GBP):</strong> @NetPremiumInGbp.ToString("N2")</div>
                     <div class="col-md-3"><strong>Strike Notional:</strong> @(StrikeNotionalLocal.ToString("N2")) @_strikeCurrency</div>
                 </div>
             </div>
         }
 
         <div class="col-12 mt-4 d-flex justify-content-center">
-            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-success e-large">Add Option Trade</SfButton>
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-success e-large">@(IsEditing ? "Update Option Trade" : "Add Option Trade")</SfButton>
         </div>
     </div>
 </div>
 
 @code {
-    [Parameter] public EventCallback OnEntryAdded { get; set; }
+    [Parameter] public EventCallback<int> OnEntryAdded { get; set; }
+    [Parameter] public int? EditingTaxEventId { get; set; }
 
     private DateTime _date = DateTime.Today;
     private string _assetName = string.Empty;
@@ -152,10 +153,12 @@
     private List<EnumDescriptionPair<PUTCALL>> _putCallTypes = [];
     private List<EnumDescriptionPair<SettlementMethods>> _settlementMethods = [];
     private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.OPTION];
+    private int? _loadedEditingTaxEventId;
+    private bool IsEditing => EditingTaxEventId.HasValue;
 
     private decimal PremiumInGbp => _premiumAmount * _premiumFxRate;
     private decimal TotalCostsInGbp => (_commissionAmount * _commissionFxRate) + (_taxAmount * _taxFxRate);
-    private decimal EstimatedNetPremiumInGbp => _tradeType == TradeType.ACQUISITION
+    private decimal NetPremiumInGbp => _tradeType == TradeType.ACQUISITION
         ? PremiumInGbp + TotalCostsInGbp
         : PremiumInGbp - TotalCostsInGbp;
     private decimal StrikeNotionalLocal => _strikePriceAmount * _quantity * _multiplier;
@@ -170,11 +173,30 @@
             .Where(e => e.EnumValue != SettlementMethods.UNKNOWN).ToList();
     }
 
+    protected override void OnParametersSet()
+    {
+        if (_loadedEditingTaxEventId != EditingTaxEventId)
+        {
+            _loadedEditingTaxEventId = EditingTaxEventId;
+            LoadForEdit();
+        }
+    }
+
     private async Task AddEntry()
     {
         if (!ValidateInputs())
         {
             return;
+        }
+
+        if (EditingTaxEventId.HasValue)
+        {
+            int removed = TaxEventLists.OptionTrades.RemoveAll(t => t.Id == EditingTaxEventId.Value);
+            if (removed == 0)
+            {
+                ToastService.ShowError("Unable to update option trade because the original entry could not be found.");
+                return;
+            }
         }
 
         List<DescribedMoney> expenses = [];
@@ -208,8 +230,49 @@
         TaxEventLists.OptionTrades.Add(trade);
         ResetForm();
 
-        ToastService.ShowSuccess($"Option trade added. Estimated net premium: {trade.NetProceed}.");
-        await OnEntryAdded.InvokeAsync();
+        ToastService.ShowSuccess($"Option trade added. Net premium: {trade.NetProceed}.");
+        await OnEntryAdded.InvokeAsync(trade.Id);
+    }
+
+    private void LoadForEdit()
+    {
+        if (!EditingTaxEventId.HasValue)
+        {
+            return;
+        }
+
+        OptionTrade? trade = TaxEventLists.OptionTrades.FirstOrDefault(t => t.Id == EditingTaxEventId.Value);
+        if (trade == null)
+        {
+            return;
+        }
+
+        _date = trade.Date;
+        _assetName = trade.AssetName;
+        _underlying = trade.Underlying;
+        _expiryDate = trade.ExpiryDate;
+        _putCall = trade.PUTCALL;
+        _tradeType = trade.AcquisitionDisposal;
+        _settlementMethod = trade.SettlementMethod;
+        _quantity = trade.Quantity;
+        _multiplier = trade.Multiplier;
+        _premiumAmount = trade.GrossProceed.Amount.Amount;
+        _premiumCurrency = trade.GrossProceed.Amount.Currency;
+        _premiumFxRate = trade.GrossProceed.FxRate;
+        _strikePriceAmount = trade.StrikePrice.Amount;
+        _strikeCurrency = trade.StrikePrice.Currency;
+
+        DescribedMoney? commission = trade.Expenses.FirstOrDefault(e => string.Equals(e.Description, "Commission", StringComparison.OrdinalIgnoreCase));
+        _commissionAmount = commission?.Amount.Amount ?? 0m;
+        _commissionCurrency = commission?.Amount.Currency ?? "GBP";
+        _commissionFxRate = commission?.FxRate ?? 1m;
+
+        DescribedMoney? tax = trade.Expenses.FirstOrDefault(e => string.Equals(e.Description, "Tax", StringComparison.OrdinalIgnoreCase));
+        _taxAmount = tax?.Amount.Amount ?? 0m;
+        _taxCurrency = tax?.Amount.Currency ?? "GBP";
+        _taxFxRate = tax?.FxRate ?? 1m;
+
+        _description = trade.Description;
     }
 
     private bool ValidateInputs()

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
@@ -21,7 +21,8 @@
                                  DateChanged="@((DateTime value) => _date = value)"
                                  AssetName="@_assetName"
                                  AssetNameChanged="@((string value) => _assetName = value)"
-                                 AssetSuggestions="@_assetSuggestions"
+                                 AllowManualAssetNameInput="true"
+                                 AssetCategoryFilter="@_assetCategoryFilter"
                                  AssetLabel="Option Contract Name"
                                  AssetPlaceholder="e.g. AAPL 2026-12-18 C 200" />
 
@@ -147,10 +148,10 @@
     private string _description = string.Empty;
 
     private List<CurrencyViewModel> _currencies = [];
-    private List<string> _assetSuggestions = [];
     private List<EnumDescriptionPair<TradeType>> _tradeTypes = [];
     private List<EnumDescriptionPair<PUTCALL>> _putCallTypes = [];
     private List<EnumDescriptionPair<SettlementMethods>> _settlementMethods = [];
+    private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.OPTION];
 
     private decimal PremiumInGbp => _premiumAmount * _premiumFxRate;
     private decimal TotalCostsInGbp => (_commissionAmount * _commissionFxRate) + (_taxAmount * _taxFxRate);
@@ -167,7 +168,6 @@
         _putCallTypes = EnumExtensions.GetEnumDescriptionPair<PUTCALL>(typeof(PUTCALL));
         _settlementMethods = EnumExtensions.GetEnumDescriptionPair<SettlementMethods>(typeof(SettlementMethods))
             .Where(e => e.EnumValue != SettlementMethods.UNKNOWN).ToList();
-        RefreshAssetSuggestions();
     }
 
     private async Task AddEntry()
@@ -206,7 +206,6 @@
         };
 
         TaxEventLists.OptionTrades.Add(trade);
-        RefreshAssetSuggestions();
         ResetForm();
 
         ToastService.ShowSuccess($"Option trade added. Estimated net premium: {trade.NetProceed}.");
@@ -292,15 +291,5 @@
         _taxAmount = 0m;
         _taxFxRate = 1m;
         _description = string.Empty;
-    }
-
-    private void RefreshAssetSuggestions()
-    {
-        _assetSuggestions = TaxEventLists.AllEvents
-            .Select(i => i.AssetName)
-            .Where(i => !string.IsNullOrWhiteSpace(i))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
-            .ToList();
     }
 }

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
@@ -192,7 +192,7 @@
         if (EditingTaxEventId.HasValue)
         {
             int removed = TaxEventLists.OptionTrades.RemoveAll(t => t.Id == EditingTaxEventId.Value);
-            if (removed == 0)
+            if (removed != 1)
             {
                 ToastService.ShowError("Unable to update option trade because the original entry could not be found.");
                 return;

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
@@ -1,0 +1,306 @@
+@using System.Collections.Immutable
+@using InvestmentTaxCalculator.Enumerations
+@using InvestmentTaxCalculator.Model
+@using InvestmentTaxCalculator.Model.TaxEvents
+@using InvestmentTaxCalculator.Services
+@using Syncfusion.Blazor.Buttons
+@using Syncfusion.Blazor.Calendars
+@using Syncfusion.Blazor.DropDowns
+@using Syncfusion.Blazor.Inputs
+
+@inject TaxEventLists TaxEventLists
+@inject CurrencyService CurrencyService
+@inject ToastService ToastService
+
+<div class="card bg-secondary text-white">
+    <div class="card-header bg-success text-white">
+        <h5 class="mb-0">Add Option Trade</h5>
+    </div>
+    <div class="card-body">
+        <ManualEntryCommonFields Date="@_date"
+                                 DateChanged="@((DateTime value) => _date = value)"
+                                 AssetName="@_assetName"
+                                 AssetNameChanged="@((string value) => _assetName = value)"
+                                 AssetSuggestions="@_assetSuggestions"
+                                 AssetLabel="Option Contract Name"
+                                 AssetPlaceholder="e.g. AAPL 2026-12-18 C 200" />
+
+        <div class="row g-3 mt-1">
+            <div class="col-md-4">
+                <label class="form-label">Underlying Asset</label>
+                <SfTextBox @bind-Value="@_underlying" Placeholder="e.g. AAPL" FloatLabelType="FloatLabelType.Never"></SfTextBox>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Expiry Date</label>
+                <SfDatePicker TValue="DateTime" @bind-Value="@_expiryDate" Format="d" CssClass="e-outline e-small"></SfDatePicker>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Put / Call</label>
+                <SfDropDownList TValue="PUTCALL" TItem="EnumDescriptionPair<PUTCALL>" DataSource="@_putCallTypes" @bind-Value="@_putCall" CssClass="e-outline e-small">
+                    <DropDownListFieldSettings Text="Description" Value="EnumValue"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+
+            <div class="col-md-4">
+                <label class="form-label">Trade Type</label>
+                <SfDropDownList TValue="TradeType" TItem="EnumDescriptionPair<TradeType>" DataSource="@_tradeTypes" @bind-Value="@_tradeType" CssClass="e-outline e-small">
+                    <DropDownListFieldSettings Text="Description" Value="EnumValue"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Quantity (contracts)</label>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="N8" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Multiplier</label>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_multiplier" Min="0" Decimals="4" Format="N4" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+            </div>
+
+            <div class="col-md-4">
+                <label class="form-label">Strike Price</label>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_strikePriceAmount" Min="0" Decimals="8" Format="N8" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Strike Currency</label>
+                <SfDropDownList TValue="string" TItem="CurrencyViewModel" DataSource="@_currencies" @bind-Value="@_strikeCurrency" CssClass="e-outline e-small">
+                    <DropDownListFieldSettings Text="Code" Value="Code"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Settlement Method</label>
+                <SfDropDownList TValue="SettlementMethods" TItem="EnumDescriptionPair<SettlementMethods>" DataSource="@_settlementMethods" @bind-Value="@_settlementMethod" CssClass="e-outline e-small">
+                    <DropDownListFieldSettings Text="Description" Value="EnumValue"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+
+            <div class="col-md-8">
+                <label class="form-label">Description</label>
+                <SfTextBox @bind-Value="@_description" Placeholder="Optional note" FloatLabelType="FloatLabelType.Never"></SfTextBox>
+            </div>
+        </div>
+
+        <AmountCurrencyFxInputRow AmountLabel="Premium"
+                                  FxRateLabel="Premium FX Rate (to GBP)"
+                                  @bind-Amount="@_premiumAmount"
+                                  @bind-Currency="@_premiumCurrency"
+                                  @bind-FxRate="@_premiumFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-3" />
+
+        <AmountCurrencyFxInputRow AmountLabel="Commission"
+                                  FxRateLabel="Commission FX Rate (to GBP)"
+                                  @bind-Amount="@_commissionAmount"
+                                  @bind-Currency="@_commissionCurrency"
+                                  @bind-FxRate="@_commissionFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-2" />
+
+        <AmountCurrencyFxInputRow AmountLabel="Tax"
+                                  FxRateLabel="Tax FX Rate (to GBP)"
+                                  @bind-Amount="@_taxAmount"
+                                  @bind-Currency="@_taxCurrency"
+                                  @bind-FxRate="@_taxFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-2" />
+
+        @if (CanShowCalculationPreview)
+        {
+            <div class="alert alert-dark border-success mt-4 mb-0">
+                <div class="row g-2">
+                    <div class="col-md-3"><strong>Premium (GBP):</strong> @PremiumInGbp.ToString("N2")</div>
+                    <div class="col-md-3"><strong>Costs (GBP):</strong> @TotalCostsInGbp.ToString("N2")</div>
+                    <div class="col-md-3"><strong>Net Premium (GBP):</strong> @EstimatedNetPremiumInGbp.ToString("N2")</div>
+                    <div class="col-md-3"><strong>Strike Notional:</strong> @(StrikeNotionalLocal.ToString("N2")) @_strikeCurrency</div>
+                </div>
+            </div>
+        }
+
+        <div class="col-12 mt-4 d-flex justify-content-center">
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-success e-large">Add Option Trade</SfButton>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback OnEntryAdded { get; set; }
+
+    private DateTime _date = DateTime.Today;
+    private string _assetName = string.Empty;
+    private string _underlying = string.Empty;
+    private DateTime _expiryDate = DateTime.Today.AddMonths(1);
+    private PUTCALL _putCall = PUTCALL.CALL;
+    private TradeType _tradeType = TradeType.ACQUISITION;
+    private SettlementMethods _settlementMethod = SettlementMethods.DELIVERY;
+    private decimal _quantity = 1m;
+    private decimal _multiplier = 100m;
+    private decimal _premiumAmount;
+    private string _premiumCurrency = "USD";
+    private decimal _premiumFxRate = 1m;
+    private decimal _strikePriceAmount = 1m;
+    private string _strikeCurrency = "USD";
+    private decimal _commissionAmount;
+    private string _commissionCurrency = "GBP";
+    private decimal _commissionFxRate = 1m;
+    private decimal _taxAmount;
+    private string _taxCurrency = "GBP";
+    private decimal _taxFxRate = 1m;
+    private string _description = string.Empty;
+
+    private List<CurrencyViewModel> _currencies = [];
+    private List<string> _assetSuggestions = [];
+    private List<EnumDescriptionPair<TradeType>> _tradeTypes = [];
+    private List<EnumDescriptionPair<PUTCALL>> _putCallTypes = [];
+    private List<EnumDescriptionPair<SettlementMethods>> _settlementMethods = [];
+
+    private decimal PremiumInGbp => _premiumAmount * _premiumFxRate;
+    private decimal TotalCostsInGbp => (_commissionAmount * _commissionFxRate) + (_taxAmount * _taxFxRate);
+    private decimal EstimatedNetPremiumInGbp => _tradeType == TradeType.ACQUISITION
+        ? PremiumInGbp + TotalCostsInGbp
+        : PremiumInGbp - TotalCostsInGbp;
+    private decimal StrikeNotionalLocal => _strikePriceAmount * _quantity * _multiplier;
+    private bool CanShowCalculationPreview => _premiumFxRate > 0 && _quantity > 0 && _multiplier > 0;
+
+    protected override void OnInitialized()
+    {
+        _currencies = CurrencyService.GetCurrencies();
+        _tradeTypes = EnumExtensions.GetEnumDescriptionPair<TradeType>(typeof(TradeType));
+        _putCallTypes = EnumExtensions.GetEnumDescriptionPair<PUTCALL>(typeof(PUTCALL));
+        _settlementMethods = EnumExtensions.GetEnumDescriptionPair<SettlementMethods>(typeof(SettlementMethods))
+            .Where(e => e.EnumValue != SettlementMethods.UNKNOWN).ToList();
+        RefreshAssetSuggestions();
+    }
+
+    private async Task AddEntry()
+    {
+        if (!ValidateInputs())
+        {
+            return;
+        }
+
+        List<DescribedMoney> expenses = [];
+        if (_commissionAmount != 0)
+        {
+            expenses.Add(new DescribedMoney(_commissionAmount, _commissionCurrency, _commissionFxRate, "Commission"));
+        }
+        if (_taxAmount != 0)
+        {
+            expenses.Add(new DescribedMoney(_taxAmount, _taxCurrency, _taxFxRate, "Tax"));
+        }
+
+        var trade = new OptionTrade
+        {
+            AssetName = _assetName.Trim(),
+            Date = _date,
+            Quantity = _quantity,
+            AcquisitionDisposal = _tradeType,
+            AssetType = AssetCategoryType.OPTION,
+            GrossProceed = new DescribedMoney(_premiumAmount, _premiumCurrency, _premiumFxRate, "Option premium"),
+            Expenses = expenses.ToImmutableList(),
+            Description = _description.Trim(),
+            Underlying = _underlying.Trim(),
+            StrikePrice = new WrappedMoney(_strikePriceAmount, _strikeCurrency),
+            ExpiryDate = _expiryDate,
+            PUTCALL = _putCall,
+            Multiplier = _multiplier,
+            SettlementMethod = _settlementMethod
+        };
+
+        TaxEventLists.OptionTrades.Add(trade);
+        RefreshAssetSuggestions();
+        ResetForm();
+
+        ToastService.ShowSuccess($"Option trade added. Estimated net premium: {trade.NetProceed}.");
+        await OnEntryAdded.InvokeAsync();
+    }
+
+    private bool ValidateInputs()
+    {
+        if (string.IsNullOrWhiteSpace(_assetName))
+        {
+            ToastService.ShowError("Option contract name is required.");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(_underlying))
+        {
+            ToastService.ShowError("Underlying asset is required.");
+            return false;
+        }
+
+        if (_quantity <= 0)
+        {
+            ToastService.ShowError("Quantity must be greater than 0.");
+            return false;
+        }
+
+        if (_multiplier <= 0)
+        {
+            ToastService.ShowError("Multiplier must be greater than 0.");
+            return false;
+        }
+
+        if (_premiumAmount < 0)
+        {
+            ToastService.ShowError("Premium cannot be negative.");
+            return false;
+        }
+
+        if (_premiumFxRate <= 0)
+        {
+            ToastService.ShowError("Premium FX rate must be greater than 0.");
+            return false;
+        }
+
+        if (_strikePriceAmount <= 0)
+        {
+            ToastService.ShowError("Strike price must be greater than 0.");
+            return false;
+        }
+
+        if (_commissionAmount != 0 && _commissionFxRate <= 0)
+        {
+            ToastService.ShowError("Commission FX rate must be greater than 0.");
+            return false;
+        }
+
+        if (_taxAmount != 0 && _taxFxRate <= 0)
+        {
+            ToastService.ShowError("Tax FX rate must be greater than 0.");
+            return false;
+        }
+
+        if (_expiryDate.Date < _date.Date)
+        {
+            ToastService.ShowWarning("Expiry date is before trade date. Please verify.");
+        }
+
+        return true;
+    }
+
+    private void ResetForm()
+    {
+        _assetName = string.Empty;
+        _underlying = string.Empty;
+        _expiryDate = DateTime.Today.AddMonths(1);
+        _quantity = 1m;
+        _multiplier = 100m;
+        _premiumAmount = 0m;
+        _premiumFxRate = 1m;
+        _strikePriceAmount = 1m;
+        _commissionAmount = 0m;
+        _commissionFxRate = 1m;
+        _taxAmount = 0m;
+        _taxFxRate = 1m;
+        _description = string.Empty;
+    }
+
+    private void RefreshAssetSuggestions()
+    {
+        _assetSuggestions = TaxEventLists.AllEvents
+            .Select(i => i.AssetName)
+            .Where(i => !string.IsNullOrWhiteSpace(i))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
@@ -50,16 +50,16 @@
             </div>
             <div class="col-md-4">
                 <label class="form-label">Quantity (contracts)</label>
-                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="N8" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="0.########" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
             </div>
             <div class="col-md-4">
                 <label class="form-label">Multiplier</label>
-                <SfNumericTextBox TValue="decimal" @bind-Value="@_multiplier" Min="0" Decimals="4" Format="N4" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_multiplier" Min="0" Decimals="8" Format="0.########" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
             </div>
 
             <div class="col-md-4">
                 <label class="form-label">Strike Price</label>
-                <SfNumericTextBox TValue="decimal" @bind-Value="@_strikePriceAmount" Min="0" Decimals="8" Format="N8" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_strikePriceAmount" Min="0" Decimals="8" Format="0.########" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
             </div>
             <div class="col-md-4">
                 <label class="form-label">Strike Currency</label>
@@ -111,7 +111,7 @@
                     <div class="col-md-3"><strong>Premium (GBP):</strong> @PremiumInGbp.ToString("N2")</div>
                     <div class="col-md-3"><strong>Costs (GBP):</strong> @TotalCostsInGbp.ToString("N2")</div>
                     <div class="col-md-3"><strong>Net Premium (GBP):</strong> @NetPremiumInGbp.ToString("N2")</div>
-                    <div class="col-md-3"><strong>Strike Notional:</strong> @(StrikeNotionalLocal.ToString("N2")) @_strikeCurrency</div>
+                    <div class="col-md-3"><strong>Strike Notional:</strong> @StrikeNotionalLocal.ToString("N2") @_strikeCurrency</div>
                 </div>
             </div>
         }
@@ -355,4 +355,5 @@
         _taxFxRate = 1m;
         _description = string.Empty;
     }
+
 }

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/OptionTradeManualEntryForm.razor
@@ -230,7 +230,8 @@
         TaxEventLists.OptionTrades.Add(trade);
         ResetForm();
 
-        ToastService.ShowSuccess($"Option trade added. Net premium: {trade.NetProceed}.");
+        string verb = IsEditing ? "updated" : "added";
+        ToastService.ShowSuccess($"Option trade {verb}. Net premium: {trade.NetProceed}.");
         await OnEntryAdded.InvokeAsync(trade.Id);
     }
 

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
@@ -32,7 +32,7 @@
             </div>
             <div class="col-md-4">
                 <label class="form-label">Quantity</label>
-                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="N8" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="0.########" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
             </div>
             <div class="col-md-4">
                 <label class="form-label">Description</label>
@@ -266,4 +266,5 @@
         _taxFxRate = 1m;
         _description = string.Empty;
     }
+
 }

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
@@ -13,7 +13,7 @@
 
 <div class="card bg-secondary text-white">
     <div class="card-header bg-primary text-white">
-        <h5 class="mb-0">Add Stock Trade</h5>
+        <h5 class="mb-0">@(IsEditing ? "Edit Stock Trade" : "Add Stock Trade")</h5>
     </div>
     <div class="card-body">
         <ManualEntryCommonFields Date="@_date"
@@ -71,19 +71,20 @@
                     <div class="col-md-3"><strong>Gross (GBP):</strong> @GrossProceedInGbp.ToString("N2")</div>
                     <div class="col-md-3"><strong>Commission (GBP):</strong> @CommissionInGbp.ToString("N2")</div>
                     <div class="col-md-3"><strong>Tax (GBP):</strong> @TaxInGbp.ToString("N2")</div>
-                    <div class="col-md-3"><strong>Estimated Net (GBP):</strong> @EstimatedNetProceedInGbp.ToString("N2")</div>
+                    <div class="col-md-3"><strong>Net (GBP):</strong> @NetProceedInGbp.ToString("N2")</div>
                 </div>
             </div>
         }
 
         <div class="col-12 mt-4 d-flex justify-content-center">
-            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-primary e-large">Add Stock Trade</SfButton>
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-primary e-large">@(IsEditing ? "Update Stock Trade" : "Add Stock Trade")</SfButton>
         </div>
     </div>
 </div>
 
 @code {
-    [Parameter] public EventCallback OnEntryAdded { get; set; }
+    [Parameter] public EventCallback<int> OnEntryAdded { get; set; }
+    [Parameter] public int? EditingTaxEventId { get; set; }
 
     private DateTime _date = DateTime.Today;
     private string _assetName = string.Empty;
@@ -103,11 +104,13 @@
     private List<CurrencyViewModel> _currencies = [];
     private List<EnumDescriptionPair<TradeType>> _tradeTypes = [];
     private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.STOCK];
+    private int? _loadedEditingTaxEventId;
+    private bool IsEditing => EditingTaxEventId.HasValue;
 
     private decimal GrossProceedInGbp => _grossProceedAmount * _grossProceedFxRate;
     private decimal CommissionInGbp => _commissionAmount * _commissionFxRate;
     private decimal TaxInGbp => _taxAmount * _taxFxRate;
-    private decimal EstimatedNetProceedInGbp => _tradeType == TradeType.ACQUISITION
+    private decimal NetProceedInGbp => _tradeType == TradeType.ACQUISITION
         ? GrossProceedInGbp + CommissionInGbp + TaxInGbp
         : GrossProceedInGbp - CommissionInGbp - TaxInGbp;
     private bool CanShowCalculationPreview => _grossProceedAmount > 0 && _grossProceedFxRate > 0;
@@ -118,11 +121,30 @@
         _tradeTypes = EnumExtensions.GetEnumDescriptionPair<TradeType>(typeof(TradeType));
     }
 
+    protected override void OnParametersSet()
+    {
+        if (_loadedEditingTaxEventId != EditingTaxEventId)
+        {
+            _loadedEditingTaxEventId = EditingTaxEventId;
+            LoadForEdit();
+        }
+    }
+
     private async Task AddEntry()
     {
         if (!ValidateInputs())
         {
             return;
+        }
+
+        if (EditingTaxEventId.HasValue)
+        {
+            int removed = TaxEventLists.Trades.RemoveAll(t => t.Id == EditingTaxEventId.Value && t.AssetType == AssetCategoryType.STOCK);
+            if (removed == 0)
+            {
+                ToastService.ShowError("Unable to update stock trade because the original entry could not be found.");
+                return;
+            }
         }
 
         List<DescribedMoney> expenses = [];
@@ -150,8 +172,45 @@
         TaxEventLists.Trades.Add(trade);
         ResetForm();
 
-        ToastService.ShowSuccess($"Stock trade added. Estimated net amount: {trade.NetProceed}.");
-        await OnEntryAdded.InvokeAsync();
+        ToastService.ShowSuccess($"Stock trade added. Net amount: {trade.NetProceed}.");
+        await OnEntryAdded.InvokeAsync(trade.Id);
+    }
+
+    private void LoadForEdit()
+    {
+        if (!EditingTaxEventId.HasValue)
+        {
+            return;
+        }
+
+        Trade? trade = TaxEventLists.Trades
+            .Where(t => t.AssetType == AssetCategoryType.STOCK)
+            .FirstOrDefault(t => t.Id == EditingTaxEventId.Value);
+
+        if (trade == null)
+        {
+            return;
+        }
+
+        _date = trade.Date;
+        _assetName = trade.AssetName;
+        _tradeType = trade.AcquisitionDisposal;
+        _quantity = trade.Quantity;
+        _grossProceedAmount = trade.GrossProceed.Amount.Amount;
+        _grossProceedCurrency = trade.GrossProceed.Amount.Currency;
+        _grossProceedFxRate = trade.GrossProceed.FxRate;
+
+        DescribedMoney? commission = trade.Expenses.FirstOrDefault(e => string.Equals(e.Description, "Commission", StringComparison.OrdinalIgnoreCase));
+        _commissionAmount = commission?.Amount.Amount ?? 0m;
+        _commissionCurrency = commission?.Amount.Currency ?? "GBP";
+        _commissionFxRate = commission?.FxRate ?? 1m;
+
+        DescribedMoney? tax = trade.Expenses.FirstOrDefault(e => string.Equals(e.Description, "Tax", StringComparison.OrdinalIgnoreCase));
+        _taxAmount = tax?.Amount.Amount ?? 0m;
+        _taxCurrency = tax?.Amount.Currency ?? "GBP";
+        _taxFxRate = tax?.FxRate ?? 1m;
+
+        _description = trade.Description;
     }
 
     private bool ValidateInputs()

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
@@ -172,7 +172,8 @@
         TaxEventLists.Trades.Add(trade);
         ResetForm();
 
-        ToastService.ShowSuccess($"Stock trade added. Net amount: {trade.NetProceed}.");
+        string verb = IsEditing ? "updated" : "added";
+        ToastService.ShowSuccess($"Stock trade {verb}. Net amount: {trade.NetProceed}.");
         await OnEntryAdded.InvokeAsync(trade.Id);
     }
 

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
@@ -20,7 +20,8 @@
                                  DateChanged="@((DateTime value) => _date = value)"
                                  AssetName="@_assetName"
                                  AssetNameChanged="@((string value) => _assetName = value)"
-                                 AssetSuggestions="@_assetSuggestions" />
+                                 AllowManualAssetNameInput="true"
+                                 AssetCategoryFilter="@_assetCategoryFilter" />
 
         <div class="row g-3 mt-1">
             <div class="col-md-4">
@@ -100,8 +101,8 @@
     private string _description = string.Empty;
 
     private List<CurrencyViewModel> _currencies = [];
-    private List<string> _assetSuggestions = [];
     private List<EnumDescriptionPair<TradeType>> _tradeTypes = [];
+    private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.STOCK];
 
     private decimal GrossProceedInGbp => _grossProceedAmount * _grossProceedFxRate;
     private decimal CommissionInGbp => _commissionAmount * _commissionFxRate;
@@ -115,7 +116,6 @@
     {
         _currencies = CurrencyService.GetCurrencies();
         _tradeTypes = EnumExtensions.GetEnumDescriptionPair<TradeType>(typeof(TradeType));
-        RefreshAssetSuggestions();
     }
 
     private async Task AddEntry()
@@ -148,7 +148,6 @@
         };
 
         TaxEventLists.Trades.Add(trade);
-        RefreshAssetSuggestions();
         ResetForm();
 
         ToastService.ShowSuccess($"Stock trade added. Estimated net amount: {trade.NetProceed}.");
@@ -207,15 +206,5 @@
         _taxAmount = 0m;
         _taxFxRate = 1m;
         _description = string.Empty;
-    }
-
-    private void RefreshAssetSuggestions()
-    {
-        _assetSuggestions = TaxEventLists.AllEvents
-            .Select(i => i.AssetName)
-            .Where(i => !string.IsNullOrWhiteSpace(i))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
-            .ToList();
     }
 }

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
@@ -140,7 +140,7 @@
         if (EditingTaxEventId.HasValue)
         {
             int removed = TaxEventLists.Trades.RemoveAll(t => t.Id == EditingTaxEventId.Value && t.AssetType == AssetCategoryType.STOCK);
-            if (removed == 0)
+            if (removed != 1)
             {
                 ToastService.ShowError("Unable to update stock trade because the original entry could not be found.");
                 return;

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/StockTradeManualEntryForm.razor
@@ -1,0 +1,221 @@
+@using System.Collections.Immutable
+@using InvestmentTaxCalculator.Enumerations
+@using InvestmentTaxCalculator.Model
+@using InvestmentTaxCalculator.Model.TaxEvents
+@using InvestmentTaxCalculator.Services
+@using Syncfusion.Blazor.Buttons
+@using Syncfusion.Blazor.DropDowns
+@using Syncfusion.Blazor.Inputs
+
+@inject TaxEventLists TaxEventLists
+@inject CurrencyService CurrencyService
+@inject ToastService ToastService
+
+<div class="card bg-secondary text-white">
+    <div class="card-header bg-primary text-white">
+        <h5 class="mb-0">Add Stock Trade</h5>
+    </div>
+    <div class="card-body">
+        <ManualEntryCommonFields Date="@_date"
+                                 DateChanged="@((DateTime value) => _date = value)"
+                                 AssetName="@_assetName"
+                                 AssetNameChanged="@((string value) => _assetName = value)"
+                                 AssetSuggestions="@_assetSuggestions" />
+
+        <div class="row g-3 mt-1">
+            <div class="col-md-4">
+                <label class="form-label">Trade Type</label>
+                <SfDropDownList TValue="TradeType" TItem="EnumDescriptionPair<TradeType>" DataSource="@_tradeTypes" @bind-Value="@_tradeType" CssClass="e-outline e-small">
+                    <DropDownListFieldSettings Text="Description" Value="EnumValue"></DropDownListFieldSettings>
+                </SfDropDownList>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Quantity</label>
+                <SfNumericTextBox TValue="decimal" @bind-Value="@_quantity" Min="0" Decimals="8" Format="N8" ShowSpinButton="false" CssClass="e-outline e-small"></SfNumericTextBox>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Description</label>
+                <SfTextBox @bind-Value="@_description" Placeholder="Optional note" FloatLabelType="FloatLabelType.Never"></SfTextBox>
+            </div>
+        </div>
+
+        <AmountCurrencyFxInputRow AmountLabel="Gross Proceed"
+                                  FxRateLabel="Gross Proceed FX Rate (to GBP)"
+                                  @bind-Amount="@_grossProceedAmount"
+                                  @bind-Currency="@_grossProceedCurrency"
+                                  @bind-FxRate="@_grossProceedFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-3" />
+
+        <AmountCurrencyFxInputRow AmountLabel="Commission"
+                                  FxRateLabel="Commission FX Rate (to GBP)"
+                                  @bind-Amount="@_commissionAmount"
+                                  @bind-Currency="@_commissionCurrency"
+                                  @bind-FxRate="@_commissionFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-2" />
+
+        <AmountCurrencyFxInputRow AmountLabel="Tax"
+                                  FxRateLabel="Tax FX Rate (to GBP)"
+                                  @bind-Amount="@_taxAmount"
+                                  @bind-Currency="@_taxCurrency"
+                                  @bind-FxRate="@_taxFxRate"
+                                  Currencies="@_currencies"
+                                  AdditionalCssClass="mt-2" />
+
+        @if (CanShowCalculationPreview)
+        {
+            <div class="alert alert-dark border-info mt-4 mb-0">
+                <div class="row g-2">
+                    <div class="col-md-3"><strong>Gross (GBP):</strong> @GrossProceedInGbp.ToString("N2")</div>
+                    <div class="col-md-3"><strong>Commission (GBP):</strong> @CommissionInGbp.ToString("N2")</div>
+                    <div class="col-md-3"><strong>Tax (GBP):</strong> @TaxInGbp.ToString("N2")</div>
+                    <div class="col-md-3"><strong>Estimated Net (GBP):</strong> @EstimatedNetProceedInGbp.ToString("N2")</div>
+                </div>
+            </div>
+        }
+
+        <div class="col-12 mt-4 d-flex justify-content-center">
+            <SfButton IsPrimary="true" OnClick="@AddEntry" CssClass="e-primary e-large">Add Stock Trade</SfButton>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback OnEntryAdded { get; set; }
+
+    private DateTime _date = DateTime.Today;
+    private string _assetName = string.Empty;
+    private TradeType _tradeType = TradeType.ACQUISITION;
+    private decimal _quantity = 1m;
+    private decimal _grossProceedAmount;
+    private string _grossProceedCurrency = "GBP";
+    private decimal _grossProceedFxRate = 1m;
+    private decimal _commissionAmount;
+    private string _commissionCurrency = "GBP";
+    private decimal _commissionFxRate = 1m;
+    private decimal _taxAmount;
+    private string _taxCurrency = "GBP";
+    private decimal _taxFxRate = 1m;
+    private string _description = string.Empty;
+
+    private List<CurrencyViewModel> _currencies = [];
+    private List<string> _assetSuggestions = [];
+    private List<EnumDescriptionPair<TradeType>> _tradeTypes = [];
+
+    private decimal GrossProceedInGbp => _grossProceedAmount * _grossProceedFxRate;
+    private decimal CommissionInGbp => _commissionAmount * _commissionFxRate;
+    private decimal TaxInGbp => _taxAmount * _taxFxRate;
+    private decimal EstimatedNetProceedInGbp => _tradeType == TradeType.ACQUISITION
+        ? GrossProceedInGbp + CommissionInGbp + TaxInGbp
+        : GrossProceedInGbp - CommissionInGbp - TaxInGbp;
+    private bool CanShowCalculationPreview => _grossProceedAmount > 0 && _grossProceedFxRate > 0;
+
+    protected override void OnInitialized()
+    {
+        _currencies = CurrencyService.GetCurrencies();
+        _tradeTypes = EnumExtensions.GetEnumDescriptionPair<TradeType>(typeof(TradeType));
+        RefreshAssetSuggestions();
+    }
+
+    private async Task AddEntry()
+    {
+        if (!ValidateInputs())
+        {
+            return;
+        }
+
+        List<DescribedMoney> expenses = [];
+        if (_commissionAmount != 0)
+        {
+            expenses.Add(new DescribedMoney(_commissionAmount, _commissionCurrency, _commissionFxRate, "Commission"));
+        }
+        if (_taxAmount != 0)
+        {
+            expenses.Add(new DescribedMoney(_taxAmount, _taxCurrency, _taxFxRate, "Tax"));
+        }
+
+        var trade = new Trade
+        {
+            AssetName = _assetName.Trim(),
+            Date = _date,
+            Quantity = _quantity,
+            AcquisitionDisposal = _tradeType,
+            AssetType = AssetCategoryType.STOCK,
+            GrossProceed = new DescribedMoney(_grossProceedAmount, _grossProceedCurrency, _grossProceedFxRate, "Gross proceed"),
+            Expenses = expenses.ToImmutableList(),
+            Description = _description.Trim()
+        };
+
+        TaxEventLists.Trades.Add(trade);
+        RefreshAssetSuggestions();
+        ResetForm();
+
+        ToastService.ShowSuccess($"Stock trade added. Estimated net amount: {trade.NetProceed}.");
+        await OnEntryAdded.InvokeAsync();
+    }
+
+    private bool ValidateInputs()
+    {
+        if (string.IsNullOrWhiteSpace(_assetName))
+        {
+            ToastService.ShowError("Asset name is required.");
+            return false;
+        }
+
+        if (_quantity <= 0)
+        {
+            ToastService.ShowError("Quantity must be greater than 0.");
+            return false;
+        }
+
+        if (_grossProceedAmount <= 0)
+        {
+            ToastService.ShowError("Gross proceed must be greater than 0.");
+            return false;
+        }
+
+        if (_grossProceedFxRate <= 0)
+        {
+            ToastService.ShowError("Gross proceed FX rate must be greater than 0.");
+            return false;
+        }
+
+        if (_commissionAmount != 0 && _commissionFxRate <= 0)
+        {
+            ToastService.ShowError("Commission FX rate must be greater than 0.");
+            return false;
+        }
+
+        if (_taxAmount != 0 && _taxFxRate <= 0)
+        {
+            ToastService.ShowError("Tax FX rate must be greater than 0.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void ResetForm()
+    {
+        _assetName = string.Empty;
+        _quantity = 1m;
+        _grossProceedAmount = 0m;
+        _grossProceedFxRate = 1m;
+        _commissionAmount = 0m;
+        _commissionFxRate = 1m;
+        _taxAmount = 0m;
+        _taxFxRate = 1m;
+        _description = string.Empty;
+    }
+
+    private void RefreshAssetSuggestions()
+    {
+        _assetSuggestions = TaxEventLists.AllEvents
+            .Select(i => i.AssetName)
+            .Where(i => !string.IsNullOrWhiteSpace(i))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(i => i, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Components/PartnerTransfer.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/PartnerTransfer.razor
@@ -2,6 +2,7 @@
 @using InvestmentTaxCalculator.Model.Interfaces
 @using InvestmentTaxCalculator.Model.TaxEvents
 @using InvestmentTaxCalculator.Model.UkTaxModel
+@using InvestmentTaxCalculator.Enumerations
 @using InvestmentTaxCalculator.Services
 @using Syncfusion.Blazor.Buttons
 @using Syncfusion.Blazor.Calendars
@@ -37,9 +38,11 @@
                 </div>
                 <div class="col-md-6">
                     <label class="form-label">Asset Ticker</label>
-                    <SfComboBox TValue="string" TItem="string" Placeholder="Select or Enter Ticker" DataSource="@_availableAssets" Value="@_ticker" AllowCustom="true">
-                        <ComboBoxEvents TItem="string" TValue="string" ValueChange="OnTickerChanged"></ComboBoxEvents>
-                    </SfComboBox>
+                    <AssetNameSelector Value="@_ticker"
+                                       ValueChanged="@OnTickerChanged"
+                                       AllowManualAssetNameInput="@AllowManualAssetNameInput"
+                                       AssetCategoryFilter="@AssetCategoryFilter"
+                                       Placeholder="Select or Enter Ticker" />
                     @if (!string.IsNullOrWhiteSpace(_ticker))
                     {
                         <div class="form-text text-info">
@@ -89,6 +92,8 @@
     [Parameter] public PartnerTransferDirection Direction { get; set; }
     [Parameter] public EventCallback OnCorporateActionAdded { get; set; }
     [Parameter] public PartnerTransferCorporateAction? ActionToEdit { get; set; }
+    [Parameter] public bool AllowManualAssetNameInput { get; set; } = true;
+    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK];
 
     private DateTime _date = DateTime.Today;
     private string? _ticker;
@@ -97,7 +102,6 @@
     private string _transferredCostCurrency = "GBP";
     private decimal _transferredCostFx = 1m;
     private decimal _currentHolding = 0m;
-    private List<string> _availableAssets = [];
     private List<CurrencyViewModel> _currencies = [];
     private PartnerTransferCorporateAction? _previousActionToEdit;
     private bool _isEditing => ActionToEdit != null;
@@ -105,10 +109,6 @@
 
     protected override void OnInitialized()
     {
-        _availableAssets = _ukSection104Pools.GetSection104s()
-            .Select(x => x.AssetName)
-            .OrderBy(x => x)
-            .ToList();
         _currencies = CurrencyService.GetCurrencies();
 
         if (ActionToEdit != null)
@@ -155,10 +155,11 @@
         await OnCorporateActionAdded.InvokeAsync();
     }
 
-    private void OnTickerChanged(ChangeEventArgs<string, string> args)
+    private Task OnTickerChanged(string ticker)
     {
-        _ticker = args.Value;
+        _ticker = ticker;
         CalculateHolding();
+        return Task.CompletedTask;
     }
 
     private void CalculateHolding()

--- a/BlazorApp-Investment Tax Calculator/Model/CountryCode.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/CountryCode.cs
@@ -24,7 +24,29 @@ public record CountryCode(string ThreeDigitCode, string CountryName)
         }
     }
 
-    private static readonly Dictionary<string, string> CountryCodes = new()
+    public static CountryCode GetRegionByThreeDigitCode(string threeDigitCode)
+    {
+        if (string.IsNullOrWhiteSpace(threeDigitCode))
+        {
+            return UnknownRegion;
+        }
+
+        if (CountryCodes.TryGetValue(threeDigitCode.ToUpperInvariant(), out string? countryName))
+        {
+            return new CountryCode(threeDigitCode.ToUpperInvariant(), countryName);
+        }
+
+        return UnknownRegion;
+    }
+
+    public static IReadOnlyList<CountryCode> GetAllRegions()
+    {
+        return [UnknownRegion, .. CountryCodes
+            .OrderBy(kv => kv.Value)
+            .Select(kv => new CountryCode(kv.Key, kv.Value))];
+    }
+
+    public static readonly Dictionary<string, string> CountryCodes = new()
     {
         { "AFG", "Afghanistan"},
         { "ALB", "Albania"},

--- a/BlazorApp-Investment Tax Calculator/Model/CountryCode.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/CountryCode.cs
@@ -11,7 +11,7 @@ public record CountryCode(string ThreeDigitCode, string CountryName)
         try
         {
             RegionInfo region = new(twoDigitCode);
-            string countryName = CountryCodes[region.ThreeLetterISORegionName];
+            string countryName = _countryCodes[region.ThreeLetterISORegionName];
             return new CountryCode(region.ThreeLetterISORegionName, countryName);
         }
         catch (KeyNotFoundException)
@@ -31,7 +31,7 @@ public record CountryCode(string ThreeDigitCode, string CountryName)
             return UnknownRegion;
         }
 
-        if (CountryCodes.TryGetValue(threeDigitCode.ToUpperInvariant(), out string? countryName))
+        if (_countryCodes.TryGetValue(threeDigitCode.ToUpperInvariant(), out string? countryName))
         {
             return new CountryCode(threeDigitCode.ToUpperInvariant(), countryName);
         }
@@ -41,12 +41,12 @@ public record CountryCode(string ThreeDigitCode, string CountryName)
 
     public static IReadOnlyList<CountryCode> GetAllRegions()
     {
-        return [UnknownRegion, .. CountryCodes
+        return [UnknownRegion, .. _countryCodes
             .OrderBy(kv => kv.Value)
             .Select(kv => new CountryCode(kv.Key, kv.Value))];
     }
 
-    public static readonly Dictionary<string, string> CountryCodes = new()
+    private static readonly Dictionary<string, string> _countryCodes = new()
     {
         { "AFG", "Afghanistan"},
         { "ALB", "Albania"},

--- a/BlazorApp-Investment Tax Calculator/Pages/AddExcessReportableIncome.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/AddExcessReportableIncome.razor
@@ -64,10 +64,16 @@
             <!-- ERI and Equalisation Controls -->
             <div class="row g-4 mb-5">
                 <div class="col-xl-6">
-                    <EriControl IsCalculationMissing="@_isCalculationMissing" OnDataChanged="RefreshAll" />
+                    <EriControl IsCalculationMissing="@_isCalculationMissing"
+                                OnDataChanged="RefreshAll"
+                                AllowManualAssetNameInput="false"
+                                AssetCategoryFilter="@_stockAssetCategoryFilter" />
                 </div>
                 <div class="col-xl-6">
-                    <EqualisationControl IsCalculationMissing="@_isCalculationMissing" OnDataChanged="RefreshAll" />
+                    <EqualisationControl IsCalculationMissing="@_isCalculationMissing"
+                                         OnDataChanged="RefreshAll"
+                                         AllowManualAssetNameInput="false"
+                                         AssetCategoryFilter="@_stockAssetCategoryFilter" />
                 </div>
             </div>
 
@@ -149,6 +155,7 @@
     private bool _isCalculationMissing = false;
     private bool _dataChanged = false;
     private IDisposable? _registration;
+    private static readonly List<AssetCategoryType> _stockAssetCategoryFilter = [AssetCategoryType.STOCK];
 
     protected override void OnInitialized()
     {

--- a/BlazorApp-Investment Tax Calculator/Pages/AddMissingTradePage.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/AddMissingTradePage.razor
@@ -5,11 +5,13 @@
 @using InvestmentTaxCalculator.Model
 @using InvestmentTaxCalculator.Model.TaxEvents
 @using InvestmentTaxCalculator.Services
+@using Syncfusion.Blazor.Buttons
 @using Syncfusion.Blazor.DropDowns
 @using Syncfusion.Blazor.Grids
 @implements IDisposable
 @inject TaxEventLists TaxEventLists
 @inject TaxCalculationService TaxCalculationService
+@inject ManualEntryTrackerService ManualEntryTrackerService
 @inject NavigationManager NavigationManager
 
 <div class="container-fluid py-5">
@@ -36,6 +38,13 @@
             </div>
 
             <div class="section mb-5">
+                @if (_editingTaxEventId.HasValue)
+                {
+                    <div class="alert alert-warning d-flex justify-content-between align-items-center mb-3">
+                        <span>Editing existing entry (ID: @_editingTaxEventId.Value). Saving will replace it.</span>
+                        <button class="btn btn-sm btn-outline-dark" @onclick="CancelEdit">Cancel Edit</button>
+                    </div>
+                }
                 <DynamicComponent Type="@SelectedEntryType.ComponentType" Parameters="@DynamicComponentParameters"></DynamicComponent>
             </div>
 
@@ -87,6 +96,20 @@
                                 </Template>
                             </GridColumn>
                             <GridColumn Field="@nameof(AddedManualEntryRow.Detail)" HeaderText="Details"></GridColumn>
+                            <GridColumn HeaderText="Actions" Width="180" AllowSorting="false" TextAlign="TextAlign.Center">
+                                <Template>
+                                    @{
+                                        var row = context as AddedManualEntryRow;
+                                    }
+                                    @if (row != null)
+                                    {
+                                        <div class="d-flex gap-2 justify-content-center">
+                                            <SfButton IconCss="e-icons e-edit" CssClass="e-primary e-small" OnClick="@(() => StartEdit(row))" Content="Edit"></SfButton>
+                                            <SfButton IconCss="e-icons e-delete" CssClass="e-danger e-small" OnClick="@(() => DeleteEntry(row))" Content="Delete"></SfButton>
+                                        </div>
+                                    }
+                                </Template>
+                            </GridColumn>
                         </GridColumns>
                     </SfGrid>
                 }
@@ -107,7 +130,7 @@
     ];
 
     private string _selectedEntryKey = "stock";
-    private HashSet<int> _baselineTaxEventIds = [];
+    private int? _editingTaxEventId;
     private List<AddedManualEntryRow> _addedEntries = [];
     private Dictionary<string, int> _entryTypeCounts = new(StringComparer.OrdinalIgnoreCase);
     private bool _hasChanges = false;
@@ -115,14 +138,14 @@
 
     private EntryTypeDefinition SelectedEntryType => _entryTypes.FirstOrDefault(i => i.Key == _selectedEntryKey) ?? _entryTypes[0];
 
-    private Dictionary<string, object> DynamicComponentParameters => new()
+    private Dictionary<string, object?> DynamicComponentParameters => new()
     {
-        [nameof(StockTradeManualEntryForm.OnEntryAdded)] = EventCallback.Factory.Create(this, OnEntryAdded)
+        [nameof(StockTradeManualEntryForm.OnEntryAdded)] = EventCallback.Factory.Create<int>(this, OnEntryAdded),
+        [nameof(StockTradeManualEntryForm.EditingTaxEventId)] = _editingTaxEventId
     };
 
     protected override void OnInitialized()
     {
-        _baselineTaxEventIds = TaxEventLists.AllEvents.Select(i => i.Id).ToHashSet();
         RefreshAddedEntries();
         _navigationRegistration = NavigationManager.RegisterLocationChangingHandler(OnLocationChanging);
     }
@@ -132,20 +155,64 @@
         if (!string.IsNullOrWhiteSpace(args.Value))
         {
             _selectedEntryKey = args.Value;
+            _editingTaxEventId = null;
         }
     }
 
-    private void OnEntryAdded()
+    private void OnEntryAdded(int taxEventId)
     {
         _hasChanges = true;
+        if (_editingTaxEventId.HasValue)
+        {
+            ManualEntryTrackerService.Remove(_editingTaxEventId.Value);
+            _editingTaxEventId = null;
+        }
+        ManualEntryTrackerService.Add(taxEventId);
         RefreshAddedEntries();
         StateHasChanged();
     }
 
+    private void StartEdit(AddedManualEntryRow row)
+    {
+        TaxEvent? taxEvent = FindTaxEventById(row.TaxEventId);
+        if (taxEvent == null) return;
+
+        _selectedEntryKey = GetEntryKeyForTaxEvent(taxEvent);
+        _editingTaxEventId = row.TaxEventId;
+        StateHasChanged();
+    }
+
+    private void CancelEdit()
+    {
+        _editingTaxEventId = null;
+    }
+
+    private void DeleteEntry(AddedManualEntryRow row)
+    {
+        if (RemoveTaxEventById(row.TaxEventId))
+        {
+            _hasChanges = true;
+            ManualEntryTrackerService.Remove(row.TaxEventId);
+            if (_editingTaxEventId == row.TaxEventId)
+            {
+                _editingTaxEventId = null;
+            }
+
+            RefreshAddedEntries();
+            StateHasChanged();
+        }
+    }
+
     private void RefreshAddedEntries()
     {
+        var existingTaxEventIds = TaxEventLists.AllEvents.Select(i => i.Id).ToHashSet();
+        foreach (int staleId in ManualEntryTrackerService.ManualEntryIds.Where(id => !existingTaxEventIds.Contains(id)).ToList())
+        {
+            ManualEntryTrackerService.Remove(staleId);
+        }
+
         _addedEntries = TaxEventLists.AllEvents
-            .Where(i => !_baselineTaxEventIds.Contains(i.Id))
+            .Where(i => ManualEntryTrackerService.ManualEntryIds.Contains(i.Id))
             .Where(IsSupportedManualEntryType)
             .Select(MapToAddedEntryRow)
             .OrderByDescending(i => i.EventDate)
@@ -160,6 +227,43 @@
     private static bool IsSupportedManualEntryType(TaxEvent taxEvent)
     {
         return taxEvent is Trade or OptionTrade or FutureContractTrade or Dividend or InterestIncome;
+    }
+
+    private TaxEvent? FindTaxEventById(int taxEventId)
+    {
+        return TaxEventLists.AllEvents.FirstOrDefault(i => i.Id == taxEventId);
+    }
+
+    private static string GetEntryKeyForTaxEvent(TaxEvent taxEvent)
+    {
+        return taxEvent switch
+        {
+            OptionTrade => "option",
+            FutureContractTrade => "future",
+            FxTrade => "fx",
+            Trade => "stock",
+            Dividend => "dividend",
+            InterestIncome => "interest",
+            _ => "stock"
+        };
+    }
+
+    private bool RemoveTaxEventById(int taxEventId)
+    {
+        int optionRemoved = TaxEventLists.OptionTrades.RemoveAll(i => i.Id == taxEventId);
+        if (optionRemoved > 0) return true;
+
+        int futureRemoved = TaxEventLists.FutureContractTrades.RemoveAll(i => i.Id == taxEventId);
+        if (futureRemoved > 0) return true;
+
+        int dividendRemoved = TaxEventLists.Dividends.RemoveAll(i => i.Id == taxEventId);
+        if (dividendRemoved > 0) return true;
+
+        int interestRemoved = TaxEventLists.InterestIncomes.RemoveAll(i => i.Id == taxEventId);
+        if (interestRemoved > 0) return true;
+
+        int tradeRemoved = TaxEventLists.Trades.RemoveAll(i => i.Id == taxEventId);
+        return tradeRemoved > 0;
     }
 
     private static AddedManualEntryRow MapToAddedEntryRow(TaxEvent taxEvent)

--- a/BlazorApp-Investment Tax Calculator/Pages/AddMissingTradePage.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/AddMissingTradePage.razor
@@ -1,25 +1,245 @@
-﻿@page "/AddTradePage"
+@page "/AddTradePage"
 
-@using InvestmentTaxCalculator.Components
+@using InvestmentTaxCalculator.Components.ManualEntries
+@using InvestmentTaxCalculator.Enumerations
+@using InvestmentTaxCalculator.Model
+@using InvestmentTaxCalculator.Model.TaxEvents
+@using InvestmentTaxCalculator.Services
+@using Syncfusion.Blazor.DropDowns
+@using Syncfusion.Blazor.Grids
+@implements IDisposable
+@inject TaxEventLists TaxEventLists
+@inject TaxCalculationService TaxCalculationService
+@inject NavigationManager NavigationManager
 
 <div class="container-fluid py-5">
     <div class="row">
         <div class="col-lg-10 mx-auto">
-            <!-- Page Header -->
             <div class="page-header text-center mb-5">
                 <h1 class="page-title">Add Manual Entries</h1>
-                <p class="page-subtitle">Manually add dividends and trades not captured in broker statements</p>
+                <p class="page-subtitle">Manually add trades, dividends, and income entries that are not included in your imported data</p>
             </div>
 
-            <!-- Add Dividend Section -->
+            <div class="row mb-5 justify-content-center">
+                <div class="col-md-5">
+                    <div class="card bg-dark border-secondary shadow-sm">
+                        <div class="card-body">
+                            <label class="form-label text-info fw-bold">Select Manual Entry Type</label>
+                            <SfDropDownList TValue="string" TItem="EntryTypeDefinition" DataSource="@_entryTypes" Value="@_selectedEntryKey" Placeholder="Choose an entry type" CssClass="e-outline">
+                                <DropDownListFieldSettings Text="DisplayName" Value="Key"></DropDownListFieldSettings>
+                                <DropDownListEvents TValue="string" TItem="EntryTypeDefinition" ValueChange="@OnEntryTypeChanged"></DropDownListEvents>
+                            </SfDropDownList>
+                            <div class="small text-muted mt-2">@SelectedEntryType.Description</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <div class="section mb-5">
-                <AddDividend/>
+                <DynamicComponent Type="@SelectedEntryType.ComponentType" Parameters="@DynamicComponentParameters"></DynamicComponent>
             </div>
 
-            <!-- Add Trade Section -->
             <div class="section">
-                <AddTrade/>
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h3 class="mb-0">Entries Added This Session</h3>
+                    <span class="badge text-bg-info">@_addedEntries.Count</span>
+                </div>
+                <p class="text-muted small mb-3">Entries are saved automatically. Tax calculations refresh when you navigate away.</p>
+
+                @if (_entryTypeCounts.Count > 0)
+                {
+                    <div class="d-flex flex-wrap gap-2 mb-3">
+                        @foreach (var count in _entryTypeCounts.OrderBy(i => i.Key))
+                        {
+                            <span class="badge text-bg-secondary">@count.Key: @count.Value</span>
+                        }
+                    </div>
+                }
+
+                @if (_addedEntries.Count == 0)
+                {
+                    <div class="alert alert-secondary alert-custom mb-0">
+                        No entries have been added on this page yet.
+                    </div>
+                }
+                else
+                {
+                    <SfGrid TValue="AddedManualEntryRow" DataSource="@_addedEntries" AllowPaging="true" AllowSorting="true">
+                        <GridPageSettings PageSize="10"></GridPageSettings>
+                        <GridColumns>
+                            <GridColumn Field="@nameof(AddedManualEntryRow.EventDate)" HeaderText="Event Date" Format="d" Type="ColumnType.Date" Width="130"></GridColumn>
+                            <GridColumn Field="@nameof(AddedManualEntryRow.EntryType)" HeaderText="Type" Width="160"></GridColumn>
+                            <GridColumn Field="@nameof(AddedManualEntryRow.AssetName)" HeaderText="Asset" Width="160"></GridColumn>
+                            <GridColumn Field="@nameof(AddedManualEntryRow.LocalAmount)" HeaderText="Local Amount" Width="170"></GridColumn>
+                            <GridColumn Field="@nameof(AddedManualEntryRow.SterlingAmount)" HeaderText="GBP Amount" Width="170"></GridColumn>
+                            <GridColumn Field="@nameof(AddedManualEntryRow.Detail)" HeaderText="Details"></GridColumn>
+                        </GridColumns>
+                    </SfGrid>
+                }
             </div>
         </div>
     </div>
 </div>
+
+@code {
+    private readonly List<EntryTypeDefinition> _entryTypes =
+    [
+        new("stock", "Stock Trade", "Add a manual stock acquisition or disposal.", typeof(StockTradeManualEntryForm)),
+        new("option", "Option Trade", "Add option premium trades with strike and expiry details.", typeof(OptionTradeManualEntryForm)),
+        new("future", "Future Contract", "Add future contract trades with contract value and position type.", typeof(FutureContractManualEntryForm)),
+        new("fx", "FX Trade", "Add foreign-currency acquisition/disposal entries.", typeof(FxTradeManualEntryForm)),
+        new("dividend", "Dividend", "Add dividend or withholding entries.", typeof(DividendManualEntryForm)),
+        new("interest", "Interest Income", "Add savings, bond, accrued, or ETF interest income.", typeof(InterestIncomeManualEntryForm))
+    ];
+
+    private string _selectedEntryKey = "stock";
+    private HashSet<int> _baselineTaxEventIds = [];
+    private List<AddedManualEntryRow> _addedEntries = [];
+    private Dictionary<string, int> _entryTypeCounts = new(StringComparer.OrdinalIgnoreCase);
+    private bool _hasChanges = false;
+    private IDisposable? _navigationRegistration;
+
+    private EntryTypeDefinition SelectedEntryType => _entryTypes.FirstOrDefault(i => i.Key == _selectedEntryKey) ?? _entryTypes[0];
+
+    private Dictionary<string, object> DynamicComponentParameters => new()
+    {
+        [nameof(StockTradeManualEntryForm.OnEntryAdded)] = EventCallback.Factory.Create(this, OnEntryAdded)
+    };
+
+    protected override void OnInitialized()
+    {
+        _baselineTaxEventIds = TaxEventLists.AllEvents.Select(i => i.Id).ToHashSet();
+        RefreshAddedEntries();
+        _navigationRegistration = NavigationManager.RegisterLocationChangingHandler(OnLocationChanging);
+    }
+
+    private void OnEntryTypeChanged(ChangeEventArgs<string, EntryTypeDefinition> args)
+    {
+        if (!string.IsNullOrWhiteSpace(args.Value))
+        {
+            _selectedEntryKey = args.Value;
+        }
+    }
+
+    private void OnEntryAdded()
+    {
+        _hasChanges = true;
+        RefreshAddedEntries();
+        StateHasChanged();
+    }
+
+    private void RefreshAddedEntries()
+    {
+        _addedEntries = TaxEventLists.AllEvents
+            .Where(i => !_baselineTaxEventIds.Contains(i.Id))
+            .Where(IsSupportedManualEntryType)
+            .Select(MapToAddedEntryRow)
+            .OrderByDescending(i => i.EventDate)
+            .ThenByDescending(i => i.TaxEventId)
+            .ToList();
+
+        _entryTypeCounts = _addedEntries
+            .GroupBy(i => i.EntryType)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSupportedManualEntryType(TaxEvent taxEvent)
+    {
+        return taxEvent is Trade or OptionTrade or FutureContractTrade or Dividend or InterestIncome;
+    }
+
+    private static AddedManualEntryRow MapToAddedEntryRow(TaxEvent taxEvent)
+    {
+        return taxEvent switch
+        {
+            OptionTrade optionTrade => new AddedManualEntryRow
+            {
+                TaxEventId = optionTrade.Id,
+                EventDate = optionTrade.Date,
+                EntryType = "Option Trade",
+                AssetName = optionTrade.AssetName,
+                LocalAmount = optionTrade.GrossProceed.Amount.ToString(),
+                SterlingAmount = optionTrade.NetProceed.ToString(),
+                Detail = $"{optionTrade.PUTCALL} {optionTrade.Quantity:N4} x {optionTrade.Multiplier:N2}, exp {optionTrade.ExpiryDate:d}"
+            },
+            FutureContractTrade futureTrade => new AddedManualEntryRow
+            {
+                TaxEventId = futureTrade.Id,
+                EventDate = futureTrade.Date,
+                EntryType = "Future Contract",
+                AssetName = futureTrade.AssetName,
+                LocalAmount = futureTrade.ContractValue.Amount.ToString(),
+                SterlingAmount = futureTrade.ContractValue.BaseCurrencyAmount.ToString(),
+                Detail = $"{futureTrade.PositionType.GetDescription()} - {futureTrade.AcquisitionDisposal.GetDescription()} {futureTrade.Quantity:N4}"
+            },
+            FxTrade fxTrade => new AddedManualEntryRow
+            {
+                TaxEventId = fxTrade.Id,
+                EventDate = fxTrade.Date,
+                EntryType = "FX Trade",
+                AssetName = fxTrade.AssetName,
+                LocalAmount = fxTrade.GrossProceed.Amount.ToString(),
+                SterlingAmount = fxTrade.NetProceed.ToString(),
+                Detail = $"{fxTrade.AcquisitionDisposal.GetDescription()} {fxTrade.Quantity:N4}"
+            },
+            Trade stockTrade => new AddedManualEntryRow
+            {
+                TaxEventId = stockTrade.Id,
+                EventDate = stockTrade.Date,
+                EntryType = "Stock Trade",
+                AssetName = stockTrade.AssetName,
+                LocalAmount = stockTrade.GrossProceed.Amount.ToString(),
+                SterlingAmount = stockTrade.NetProceed.ToString(),
+                Detail = $"{stockTrade.AcquisitionDisposal.GetDescription()} {stockTrade.Quantity:N4}"
+            },
+            Dividend dividend => new AddedManualEntryRow
+            {
+                TaxEventId = dividend.Id,
+                EventDate = dividend.Date,
+                EntryType = "Dividend",
+                AssetName = dividend.AssetName,
+                LocalAmount = dividend.Proceed.Amount.ToString(),
+                SterlingAmount = dividend.Proceed.BaseCurrencyAmount.ToString(),
+                Detail = dividend.DividendType.GetDescription()
+            },
+            InterestIncome interestIncome => new AddedManualEntryRow
+            {
+                TaxEventId = interestIncome.Id,
+                EventDate = interestIncome.Date,
+                EntryType = "Interest Income",
+                AssetName = interestIncome.AssetName,
+                LocalAmount = interestIncome.Amount.Amount.ToString(),
+                SterlingAmount = interestIncome.Amount.BaseCurrencyAmount.ToString(),
+                Detail = interestIncome.InterestType.GetDescription() + (interestIncome.IsTaxDeferred ? " (Tax Deferred)" : string.Empty)
+            },
+            _ => throw new InvalidOperationException($"Unsupported tax event type: {taxEvent.GetType().Name}")
+        };
+    }
+
+    private async ValueTask OnLocationChanging(LocationChangingContext _)
+    {
+        if (_hasChanges)
+        {
+            _hasChanges = false;
+            await TaxCalculationService.CalculateAsync(CalculationTrigger.NavigationRefresh);
+        }
+    }
+
+    public void Dispose()
+    {
+        _navigationRegistration?.Dispose();
+    }
+
+    private sealed record EntryTypeDefinition(string Key, string DisplayName, string Description, Type ComponentType);
+
+    private sealed class AddedManualEntryRow
+    {
+        public int TaxEventId { get; init; }
+        public DateTime EventDate { get; init; }
+        public string EntryType { get; init; } = string.Empty;
+        public string AssetName { get; init; } = string.Empty;
+        public string LocalAmount { get; init; } = string.Empty;
+        public string SterlingAmount { get; init; } = string.Empty;
+        public string Detail { get; init; } = string.Empty;
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Pages/AddMissingTradePage.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/AddMissingTradePage.razor
@@ -79,20 +79,20 @@
                             <GridColumn Field="@nameof(AddedManualEntryRow.EventDate)" HeaderText="Event Date" Format="d" Type="ColumnType.Date" Width="130"></GridColumn>
                             <GridColumn Field="@nameof(AddedManualEntryRow.EntryType)" HeaderText="Type" Width="160"></GridColumn>
                             <GridColumn Field="@nameof(AddedManualEntryRow.AssetName)" HeaderText="Asset" Width="160"></GridColumn>
-                            <GridColumn Field="@nameof(AddedManualEntryRow.LocalAmountValue)" HeaderText="Local Amount" Width="170">
+                            <GridColumn Field="@nameof(AddedManualEntryRow.GrossProceedLocalValue)" HeaderText="Gross Proceed (Local)" Width="190">
                                 <Template>
                                     @{
                                         var row = context as AddedManualEntryRow;
                                     }
-                                    @row?.LocalAmount
+                                    @row?.GrossProceedLocal
                                 </Template>
                             </GridColumn>
-                            <GridColumn Field="@nameof(AddedManualEntryRow.SterlingAmountValue)" HeaderText="GBP Amount" Width="170">
+                            <GridColumn Field="@nameof(AddedManualEntryRow.NetSterlingValue)" HeaderText="Net (GBP incl. tax & commission)" Width="240">
                                 <Template>
                                     @{
                                         var row = context as AddedManualEntryRow;
                                     }
-                                    @row?.SterlingAmount
+                                    @row?.NetSterling
                                 </Template>
                             </GridColumn>
                             <GridColumn Field="@nameof(AddedManualEntryRow.Detail)" HeaderText="Details"></GridColumn>
@@ -276,9 +276,9 @@
                 EventDate = optionTrade.Date,
                 EntryType = "Option Trade",
                 AssetName = optionTrade.AssetName,
-                LocalAmount = optionTrade.GrossProceed.Amount,
-                SterlingAmount = optionTrade.NetProceed,
-                Detail = $"{optionTrade.PUTCALL} {optionTrade.Quantity:N4} x {optionTrade.Multiplier:N2}, exp {optionTrade.ExpiryDate:d}"
+                GrossProceedLocal = optionTrade.GrossProceed.Amount,
+                NetSterling = optionTrade.NetProceed,
+                Detail = $"{optionTrade.PUTCALL} {FormatQuantity(optionTrade.Quantity)} x {FormatQuantity(optionTrade.Multiplier)}, exp {optionTrade.ExpiryDate:d}"
             },
             FutureContractTrade futureTrade => new AddedManualEntryRow
             {
@@ -286,9 +286,9 @@
                 EventDate = futureTrade.Date,
                 EntryType = "Future Contract",
                 AssetName = futureTrade.AssetName,
-                LocalAmount = futureTrade.ContractValue.Amount,
-                SterlingAmount = futureTrade.ContractValue.BaseCurrencyAmount,
-                Detail = $"{futureTrade.PositionType.GetDescription()} - {futureTrade.AcquisitionDisposal.GetDescription()} {futureTrade.Quantity:N4}"
+                GrossProceedLocal = futureTrade.ContractValue.Amount,
+                NetSterling = futureTrade.ContractValue.BaseCurrencyAmount,
+                Detail = $"{futureTrade.PositionType.GetDescription()} - {futureTrade.AcquisitionDisposal.GetDescription()} {FormatQuantity(futureTrade.Quantity)}"
             },
             FxTrade fxTrade => new AddedManualEntryRow
             {
@@ -296,9 +296,9 @@
                 EventDate = fxTrade.Date,
                 EntryType = "FX Trade",
                 AssetName = fxTrade.AssetName,
-                LocalAmount = fxTrade.GrossProceed.Amount,
-                SterlingAmount = fxTrade.NetProceed,
-                Detail = $"{fxTrade.AcquisitionDisposal.GetDescription()} {fxTrade.Quantity:N4}"
+                GrossProceedLocal = fxTrade.GrossProceed.Amount,
+                NetSterling = fxTrade.NetProceed,
+                Detail = $"{fxTrade.AcquisitionDisposal.GetDescription()} {FormatQuantity(fxTrade.Quantity)}"
             },
             Trade stockTrade => new AddedManualEntryRow
             {
@@ -306,9 +306,9 @@
                 EventDate = stockTrade.Date,
                 EntryType = "Stock Trade",
                 AssetName = stockTrade.AssetName,
-                LocalAmount = stockTrade.GrossProceed.Amount,
-                SterlingAmount = stockTrade.NetProceed,
-                Detail = $"{stockTrade.AcquisitionDisposal.GetDescription()} {stockTrade.Quantity:N4}"
+                GrossProceedLocal = stockTrade.GrossProceed.Amount,
+                NetSterling = stockTrade.NetProceed,
+                Detail = $"{stockTrade.AcquisitionDisposal.GetDescription()} {FormatQuantity(stockTrade.Quantity)}"
             },
             Dividend dividend => new AddedManualEntryRow
             {
@@ -316,8 +316,8 @@
                 EventDate = dividend.Date,
                 EntryType = "Dividend",
                 AssetName = dividend.AssetName,
-                LocalAmount = dividend.Proceed.Amount,
-                SterlingAmount = dividend.Proceed.BaseCurrencyAmount,
+                GrossProceedLocal = dividend.Proceed.Amount,
+                NetSterling = dividend.Proceed.BaseCurrencyAmount,
                 Detail = dividend.DividendType.GetDescription()
             },
             InterestIncome interestIncome => new AddedManualEntryRow
@@ -326,12 +326,17 @@
                 EventDate = interestIncome.Date,
                 EntryType = "Interest Income",
                 AssetName = interestIncome.AssetName,
-                LocalAmount = interestIncome.Amount.Amount,
-                SterlingAmount = interestIncome.Amount.BaseCurrencyAmount,
+                GrossProceedLocal = interestIncome.Amount.Amount,
+                NetSterling = interestIncome.Amount.BaseCurrencyAmount,
                 Detail = interestIncome.InterestType.GetDescription() + (interestIncome.IsTaxDeferred ? " (Tax Deferred)" : string.Empty)
             },
             _ => throw new InvalidOperationException($"Unsupported tax event type: {taxEvent.GetType().Name}")
         };
+    }
+
+    private static string FormatQuantity(decimal quantity)
+    {
+        return quantity.ToString("0.########");
     }
 
     private async ValueTask OnLocationChanging(LocationChangingContext _)
@@ -356,10 +361,10 @@
         public DateTime EventDate { get; init; }
         public string EntryType { get; init; } = string.Empty;
         public string AssetName { get; init; } = string.Empty;
-        public WrappedMoney LocalAmount { get; init; } = WrappedMoney.GetBaseCurrencyZero();
-        public WrappedMoney SterlingAmount { get; init; } = WrappedMoney.GetBaseCurrencyZero();
-        public decimal LocalAmountValue => LocalAmount.Amount;
-        public decimal SterlingAmountValue => SterlingAmount.Amount;
+        public WrappedMoney GrossProceedLocal { get; init; } = WrappedMoney.GetBaseCurrencyZero();
+        public WrappedMoney NetSterling { get; init; } = WrappedMoney.GetBaseCurrencyZero();
+        public decimal GrossProceedLocalValue => GrossProceedLocal.Amount;
+        public decimal NetSterlingValue => NetSterling.Amount;
         public string Detail { get; init; } = string.Empty;
     }
 }

--- a/BlazorApp-Investment Tax Calculator/Pages/AddMissingTradePage.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/AddMissingTradePage.razor
@@ -70,8 +70,22 @@
                             <GridColumn Field="@nameof(AddedManualEntryRow.EventDate)" HeaderText="Event Date" Format="d" Type="ColumnType.Date" Width="130"></GridColumn>
                             <GridColumn Field="@nameof(AddedManualEntryRow.EntryType)" HeaderText="Type" Width="160"></GridColumn>
                             <GridColumn Field="@nameof(AddedManualEntryRow.AssetName)" HeaderText="Asset" Width="160"></GridColumn>
-                            <GridColumn Field="@nameof(AddedManualEntryRow.LocalAmount)" HeaderText="Local Amount" Width="170"></GridColumn>
-                            <GridColumn Field="@nameof(AddedManualEntryRow.SterlingAmount)" HeaderText="GBP Amount" Width="170"></GridColumn>
+                            <GridColumn Field="@nameof(AddedManualEntryRow.LocalAmountValue)" HeaderText="Local Amount" Width="170">
+                                <Template>
+                                    @{
+                                        var row = context as AddedManualEntryRow;
+                                    }
+                                    @row?.LocalAmount
+                                </Template>
+                            </GridColumn>
+                            <GridColumn Field="@nameof(AddedManualEntryRow.SterlingAmountValue)" HeaderText="GBP Amount" Width="170">
+                                <Template>
+                                    @{
+                                        var row = context as AddedManualEntryRow;
+                                    }
+                                    @row?.SterlingAmount
+                                </Template>
+                            </GridColumn>
                             <GridColumn Field="@nameof(AddedManualEntryRow.Detail)" HeaderText="Details"></GridColumn>
                         </GridColumns>
                     </SfGrid>
@@ -158,8 +172,8 @@
                 EventDate = optionTrade.Date,
                 EntryType = "Option Trade",
                 AssetName = optionTrade.AssetName,
-                LocalAmount = optionTrade.GrossProceed.Amount.ToString(),
-                SterlingAmount = optionTrade.NetProceed.ToString(),
+                LocalAmount = optionTrade.GrossProceed.Amount,
+                SterlingAmount = optionTrade.NetProceed,
                 Detail = $"{optionTrade.PUTCALL} {optionTrade.Quantity:N4} x {optionTrade.Multiplier:N2}, exp {optionTrade.ExpiryDate:d}"
             },
             FutureContractTrade futureTrade => new AddedManualEntryRow
@@ -168,8 +182,8 @@
                 EventDate = futureTrade.Date,
                 EntryType = "Future Contract",
                 AssetName = futureTrade.AssetName,
-                LocalAmount = futureTrade.ContractValue.Amount.ToString(),
-                SterlingAmount = futureTrade.ContractValue.BaseCurrencyAmount.ToString(),
+                LocalAmount = futureTrade.ContractValue.Amount,
+                SterlingAmount = futureTrade.ContractValue.BaseCurrencyAmount,
                 Detail = $"{futureTrade.PositionType.GetDescription()} - {futureTrade.AcquisitionDisposal.GetDescription()} {futureTrade.Quantity:N4}"
             },
             FxTrade fxTrade => new AddedManualEntryRow
@@ -178,8 +192,8 @@
                 EventDate = fxTrade.Date,
                 EntryType = "FX Trade",
                 AssetName = fxTrade.AssetName,
-                LocalAmount = fxTrade.GrossProceed.Amount.ToString(),
-                SterlingAmount = fxTrade.NetProceed.ToString(),
+                LocalAmount = fxTrade.GrossProceed.Amount,
+                SterlingAmount = fxTrade.NetProceed,
                 Detail = $"{fxTrade.AcquisitionDisposal.GetDescription()} {fxTrade.Quantity:N4}"
             },
             Trade stockTrade => new AddedManualEntryRow
@@ -188,8 +202,8 @@
                 EventDate = stockTrade.Date,
                 EntryType = "Stock Trade",
                 AssetName = stockTrade.AssetName,
-                LocalAmount = stockTrade.GrossProceed.Amount.ToString(),
-                SterlingAmount = stockTrade.NetProceed.ToString(),
+                LocalAmount = stockTrade.GrossProceed.Amount,
+                SterlingAmount = stockTrade.NetProceed,
                 Detail = $"{stockTrade.AcquisitionDisposal.GetDescription()} {stockTrade.Quantity:N4}"
             },
             Dividend dividend => new AddedManualEntryRow
@@ -198,8 +212,8 @@
                 EventDate = dividend.Date,
                 EntryType = "Dividend",
                 AssetName = dividend.AssetName,
-                LocalAmount = dividend.Proceed.Amount.ToString(),
-                SterlingAmount = dividend.Proceed.BaseCurrencyAmount.ToString(),
+                LocalAmount = dividend.Proceed.Amount,
+                SterlingAmount = dividend.Proceed.BaseCurrencyAmount,
                 Detail = dividend.DividendType.GetDescription()
             },
             InterestIncome interestIncome => new AddedManualEntryRow
@@ -208,8 +222,8 @@
                 EventDate = interestIncome.Date,
                 EntryType = "Interest Income",
                 AssetName = interestIncome.AssetName,
-                LocalAmount = interestIncome.Amount.Amount.ToString(),
-                SterlingAmount = interestIncome.Amount.BaseCurrencyAmount.ToString(),
+                LocalAmount = interestIncome.Amount.Amount,
+                SterlingAmount = interestIncome.Amount.BaseCurrencyAmount,
                 Detail = interestIncome.InterestType.GetDescription() + (interestIncome.IsTaxDeferred ? " (Tax Deferred)" : string.Empty)
             },
             _ => throw new InvalidOperationException($"Unsupported tax event type: {taxEvent.GetType().Name}")
@@ -238,8 +252,10 @@
         public DateTime EventDate { get; init; }
         public string EntryType { get; init; } = string.Empty;
         public string AssetName { get; init; } = string.Empty;
-        public string LocalAmount { get; init; } = string.Empty;
-        public string SterlingAmount { get; init; } = string.Empty;
+        public WrappedMoney LocalAmount { get; init; } = WrappedMoney.GetBaseCurrencyZero();
+        public WrappedMoney SterlingAmount { get; init; } = WrappedMoney.GetBaseCurrencyZero();
+        public decimal LocalAmountValue => LocalAmount.Amount;
+        public decimal SterlingAmountValue => SterlingAmount.Amount;
         public string Detail { get; init; } = string.Empty;
     }
 }

--- a/BlazorApp-Investment Tax Calculator/Pages/NavMenu.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/NavMenu.razor
@@ -118,7 +118,7 @@
             new MenuCategory { 
                 Title = "Configurations and manual inputs",
                 Items = new() {
-                    new MenuItem { Text = "Add Trades", PageAddress = "AddTradePage", Icon = "➕" },
+                    new MenuItem { Text = "Add Manual Entries", PageAddress = "AddTradePage", Icon = "➕" },
                     new MenuItem { Text = "Residency Status", PageAddress = "ResidencyStatusPage", Icon = "🌍" },
                     new MenuItem { Text = "ERI and Equalisation", PageAddress = "AddExcessReportableIncome", Icon = "⚖️" },
                     new MenuItem { Text = "Corporate Actions and Events", PageAddress = "corporate-actions", Icon = "🏢" },

--- a/BlazorApp-Investment Tax Calculator/Pages/TakeoverCorporateActionPage.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/TakeoverCorporateActionPage.razor
@@ -1,6 +1,7 @@
 @page "/corporate-actions"
 
 @using InvestmentTaxCalculator.Components
+@using InvestmentTaxCalculator.Enumerations
 @using InvestmentTaxCalculator.Model.TaxEvents
 @using StockSplitAction = InvestmentTaxCalculator.Model.TaxEvents.StockSplit
 @using InvestmentTaxCalculator.Services
@@ -50,12 +51,16 @@
                 {
                     <PartnerTransfer Direction="PartnerTransferDirection.GiftToPartner"
                                      OnCorporateActionAdded="OnActionModified"
+                                     AllowManualAssetNameInput="false"
+                                     AssetCategoryFilter="@_stockAssetCategoryFilter"
                                      ActionToEdit="GetPartnerActionToEdit(PartnerTransferDirection.GiftToPartner)" />
                 }
                 else if (_selectedAction == "Receive from partner")
                 {
                     <PartnerTransfer Direction="PartnerTransferDirection.ReceiveFromPartner"
                                      OnCorporateActionAdded="OnActionModified"
+                                     AllowManualAssetNameInput="true"
+                                     AssetCategoryFilter="@_stockAssetCategoryFilter"
                                      ActionToEdit="GetPartnerActionToEdit(PartnerTransferDirection.ReceiveFromPartner)" />
                 }
             </div>
@@ -72,6 +77,7 @@
     private CorporateActionsList? _historyList;
     private bool _hasChanges = false;
     private IDisposable? _navigationRegistration;
+    private static readonly List<AssetCategoryType> _stockAssetCategoryFilter = [AssetCategoryType.STOCK];
     
     private List<string> _actionTypes = new() { "Takeover / Merger", "Spinoff", "Stock Split / Reverse Split", "Gift to partner", "Receive from partner" };
     private string? _selectedAction = "Takeover / Merger";

--- a/BlazorApp-Investment Tax Calculator/Program.cs
+++ b/BlazorApp-Investment Tax Calculator/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddSingleton<TaxYearCgtByTypeReportService>();
 builder.Services.AddSingleton<PdfExportService>();
 builder.Services.AddSingleton<TaxCalculationService>();
 builder.Services.AddSingleton<CurrencyService>();
+builder.Services.AddSingleton<ManualEntryTrackerService>();
 builder.Services.AddScoped<FileImportStateService>();
 
 // UK tax specific components - replace if you want to calculate some other countries.

--- a/BlazorApp-Investment Tax Calculator/Services/ManualEntryTrackerService.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/ManualEntryTrackerService.cs
@@ -1,0 +1,26 @@
+namespace InvestmentTaxCalculator.Services;
+
+public sealed class ManualEntryTrackerService
+{
+    private readonly HashSet<int> _manualEntryIds = [];
+
+    public IReadOnlyCollection<int> ManualEntryIds => _manualEntryIds;
+
+    public void Add(int taxEventId)
+    {
+        _manualEntryIds.Add(taxEventId);
+    }
+
+    public void AddRange(IEnumerable<int> taxEventIds)
+    {
+        foreach (int taxEventId in taxEventIds)
+        {
+            _manualEntryIds.Add(taxEventId);
+        }
+    }
+
+    public void Remove(int taxEventId)
+    {
+        _manualEntryIds.Remove(taxEventId);
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/wwwroot/css/app.css
+++ b/BlazorApp-Investment Tax Calculator/wwwroot/css/app.css
@@ -119,6 +119,27 @@
     color: var(--bs-heading-color);
 }
 
+.manual-money-entry {
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.375rem;
+    padding: 0.75rem;
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.manual-money-entry-title {
+    display: block;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--bs-info);
+    margin-bottom: 0.5rem;
+}
+
+.manual-money-row .e-control-wrapper,
+.manual-money-row .e-ddl,
+.manual-money-row .e-numerictextbox {
+    width: 100%;
+}
+
 /* Utility Classes */
 .text-muted-custom {
     color: var(--bs-secondary-color) !important;

--- a/PlaywrightTests/ManualEntryTests.cs
+++ b/PlaywrightTests/ManualEntryTests.cs
@@ -1,0 +1,252 @@
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace PlaywrightTests;
+
+/// <summary>
+/// Tests that each manual entry type can be successfully added via the Add Manual Entries page.
+/// Each test navigates to /AddTradePage, fills the form, clicks Add, and verifies the entry appears in the grid.
+/// </summary>
+[TestFixture]
+public class ManualEntryTests : PlaywrightTestBase
+{
+    private const string PagePath = "/AddTradePage";
+
+    [Test]
+    public async Task CanAddStockTrade()
+    {
+        await NavigateAndWaitForBlazorAsync(PagePath);
+        await WaitForTextAsync("Add Stock Trade");
+
+        await FillComboBox("Enter ticker or asset name", "TESTSTOCK");
+        await FillNumericByLabel("Quantity", "10");
+        await FillMoneyAmountByTitle("Gross Proceed", "1000");
+
+        await ClickButtonByText("Add Stock Trade");
+        await VerifySuccessToast("added");
+        await VerifyGridRowCount(1);
+        await VerifyGridContainsText("TESTSTOCK");
+    }
+
+    [Test]
+    public async Task CanAddOptionTrade()
+    {
+        await NavigateAndWaitForBlazorAsync(PagePath);
+        await SelectEntryType("Option Trade");
+        await WaitForTextAsync("Add Option Trade");
+
+        await FillFirstComboBox("AAPL C 200 TEST");
+        await FillTextByLabel("Underlying Asset", "AAPL");
+        await FillNumericByLabel("Quantity (contracts)", "5");
+        await FillMoneyAmountByTitle("Premium", "500");
+
+        await ClickButtonByText("Add Option Trade");
+        await VerifySuccessToast("added");
+        await VerifyGridRowCount(1);
+        await VerifyGridContainsText("Option Trade");
+    }
+
+    [Test]
+    public async Task CanAddFutureContract()
+    {
+        await NavigateAndWaitForBlazorAsync(PagePath);
+        await SelectEntryType("Future Contract");
+        await WaitForTextAsync("Add Future Contract Trade");
+
+        await FillComboBox("Enter ticker or asset name", "ES-TEST");
+        await FillMoneyAmountByTitle("Contract Value", "5000");
+
+        await ClickButtonByText("Add Future Trade");
+        await VerifySuccessToast("added");
+        await VerifyGridRowCount(1);
+        await VerifyGridContainsText("Future Contract");
+    }
+
+    [Test]
+    public async Task CanAddFxTrade()
+    {
+        await NavigateAndWaitForBlazorAsync(PagePath);
+        await SelectEntryType("FX Trade");
+        await WaitForTextAsync("Add FX Trade");
+
+        // FX Trade defaults asset name to "USD"
+        await FillNumericByLabel("Quantity", "1000");
+        await FillMoneyAmountByTitle("Gross Proceed", "800");
+
+        await ClickButtonByText("Add FX Trade");
+        await VerifySuccessToast("added");
+        await VerifyGridRowCount(1);
+        await VerifyGridContainsText("FX Trade");
+    }
+
+    [Test]
+    public async Task CanAddDividend()
+    {
+        await NavigateAndWaitForBlazorAsync(PagePath);
+        await SelectEntryType("Dividend");
+        await WaitForTextAsync("Add Dividend");
+
+        await FillComboBox("Enter ticker or asset name", "MSFT-TEST");
+        await FillMoneyAmountByTitle("Amount", "50");
+
+        await ClickButtonByText("Add Dividend");
+        await VerifySuccessToast("added");
+        await VerifyGridRowCount(1);
+        await VerifyGridContainsText("MSFT-TEST");
+    }
+
+    [Test]
+    public async Task CanAddInterestIncome()
+    {
+        await NavigateAndWaitForBlazorAsync(PagePath);
+        await SelectEntryType("Interest Income");
+        await WaitForTextAsync("Add Interest Income");
+
+        await FillComboBox("Enter ticker or asset name", "SAVINGS-TEST");
+        await FillMoneyAmountByTitle("Amount", "100");
+
+        await ClickButtonByText("Add Interest Income");
+        await VerifySuccessToast("added");
+        await VerifyGridRowCount(1);
+        await VerifyGridContainsText("SAVINGS-TEST");
+    }
+
+    // ───────────────────── Helper methods ─────────────────────
+
+    /// <summary>
+    /// Selects an entry type from the page-level Syncfusion DropDownList.
+    /// </summary>
+    private async Task SelectEntryType(string entryTypeName)
+    {
+        // The entry type dropdown is inside .card.bg-dark
+        var dropdown = Page.Locator(".card.bg-dark .e-ddl");
+        await dropdown.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 5000 });
+        await dropdown.ClickAsync();
+
+        // Wait for popup and click the item
+        var listItem = Page.Locator($".e-dropdownbase .e-list-item:has-text('{entryTypeName}')").First;
+        await listItem.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 5000 });
+        await listItem.ClickAsync();
+    }
+
+    /// <summary>
+    /// Fills the first Syncfusion ComboBox on the form card (for asset name).
+    /// Works regardless of placeholder text variations across entry types.
+    /// </summary>
+    private async Task FillFirstComboBox(string value)
+    {
+        var input = Page.Locator(".card.bg-secondary input.e-combobox").First;
+        await input.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 5000 });
+        await input.ClickAsync();
+        await input.FillAsync(value);
+        await input.PressAsync("Tab");
+    }
+
+    /// <summary>
+    /// Fills a Syncfusion ComboBox identified by its placeholder text.
+    /// </summary>
+    private async Task FillComboBox(string placeholder, string value)
+    {
+        var input = Page.Locator($"input.e-combobox[placeholder='{placeholder}']").First;
+        await input.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 5000 });
+        await input.ClickAsync();
+        await input.FillAsync(value);
+        await input.PressAsync("Tab");
+    }
+
+    /// <summary>
+    /// Fills a Syncfusion NumericTextBox located near a label with the given text.
+    /// Finds the label, then locates the sibling numeric input in the same container.
+    /// </summary>
+    private async Task FillNumericByLabel(string labelText, string value)
+    {
+        // Find label, go to parent container, find the numeric input
+        var label = Page.Locator($".card.bg-secondary label.form-label:text-is('{labelText}')").First;
+        var container = label.Locator("xpath=..");
+        var input = container.Locator("input.e-numerictextbox").First;
+
+        await input.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 5000 });
+        await input.ClickAsync(new LocatorClickOptions { ClickCount = 3 });
+        await input.FillAsync(value);
+        await input.PressAsync("Tab");
+    }
+
+    /// <summary>
+    /// Fills the Amount numeric input inside the reusable money row identified by its title.
+    /// </summary>
+    private async Task FillMoneyAmountByTitle(string rowTitle, string value)
+    {
+        var rowTitleLocator = Page.Locator($".manual-money-entry-title:text-is('{rowTitle}')").First;
+        await rowTitleLocator.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 5000 });
+        var rowContainer = rowTitleLocator.Locator("xpath=..");
+        var amountInput = rowContainer.Locator("input.e-numerictextbox").First;
+
+        await amountInput.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 5000 });
+        await amountInput.ClickAsync(new LocatorClickOptions { ClickCount = 3 });
+        await amountInput.FillAsync(value);
+        await amountInput.PressAsync("Tab");
+    }
+
+    /// <summary>
+    /// Fills a Syncfusion TextBox located near a label with the given text.
+    /// Uses the e-textbox wrapper to disambiguate from numeric inputs.
+    /// </summary>
+    private async Task FillTextByLabel(string labelText, string value)
+    {
+        var label = Page.Locator($"label.form-label:has-text('{labelText}')").First;
+        var container = label.Locator("xpath=..");
+        var input = container.Locator("input.e-textbox").First;
+
+        await input.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 5000 });
+        await input.ClickAsync();
+        await input.FillAsync(value);
+        await input.PressAsync("Tab");
+    }
+
+    /// <summary>
+    /// Clicks a button by its visible text.
+    /// </summary>
+    private async Task ClickButtonByText(string buttonText)
+    {
+        var button = Page.Locator($"button.e-btn:has-text('{buttonText}')").First;
+        await button.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 5000 });
+        await button.ScrollIntoViewIfNeededAsync();
+        await button.ClickAsync();
+    }
+
+    /// <summary>
+    /// Verifies a Syncfusion toast containing expected text appeared.
+    /// </summary>
+    private async Task VerifySuccessToast(string expectedText)
+    {
+        var toast = Page.Locator($".e-toast:has-text('{expectedText}')").First;
+        await toast.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = 10000
+        });
+        TestContext.WriteLine($"Success toast appeared containing '{expectedText}'");
+    }
+
+    /// <summary>
+    /// Verifies the Added Entries grid has the expected number of data rows.
+    /// </summary>
+    private async Task VerifyGridRowCount(int expectedCount)
+    {
+        var rows = Page.Locator(".e-grid .e-row");
+        await Expect(rows).ToHaveCountAsync(expectedCount, new LocatorAssertionsToHaveCountOptions { Timeout = 10000 });
+        var count = await rows.CountAsync();
+        TestContext.WriteLine($"Grid row count: {count}");
+        Assert.That(count, Is.EqualTo(expectedCount),
+            $"Expected {expectedCount} rows in the Added Entries grid, but found {count}");
+    }
+
+    /// <summary>
+    /// Verifies the grid contains a cell with the expected text.
+    /// </summary>
+    private async Task VerifyGridContainsText(string expectedText)
+    {
+        var cell = Page.Locator($".e-grid .e-rowcell:has-text('{expectedText}')").First;
+        await Expect(cell).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 5000 });
+    }
+}

--- a/PlaywrightTests/ManualEntryTests.cs
+++ b/PlaywrightTests/ManualEntryTests.cs
@@ -17,6 +17,7 @@ public class ManualEntryTests : PlaywrightTestBase
     {
         await NavigateAndWaitForBlazorAsync(PagePath);
         await WaitForTextAsync("Add Stock Trade");
+        int preCount = await GetCurrentGridRowCount();
 
         await FillComboBox("Enter ticker or asset name", "TESTSTOCK");
         await FillNumericByLabel("Quantity", "10");
@@ -24,7 +25,7 @@ public class ManualEntryTests : PlaywrightTestBase
 
         await ClickButtonByText("Add Stock Trade");
         await VerifySuccessToast("added");
-        await VerifyGridRowCount(1);
+        await VerifyGridRowCount(preCount + 1);
         await VerifyGridContainsText("TESTSTOCK");
     }
 
@@ -34,6 +35,7 @@ public class ManualEntryTests : PlaywrightTestBase
         await NavigateAndWaitForBlazorAsync(PagePath);
         await SelectEntryType("Option Trade");
         await WaitForTextAsync("Add Option Trade");
+        int preCount = await GetCurrentGridRowCount();
 
         await FillFirstComboBox("AAPL C 200 TEST");
         await FillTextByLabel("Underlying Asset", "AAPL");
@@ -42,7 +44,7 @@ public class ManualEntryTests : PlaywrightTestBase
 
         await ClickButtonByText("Add Option Trade");
         await VerifySuccessToast("added");
-        await VerifyGridRowCount(1);
+        await VerifyGridRowCount(preCount + 1);
         await VerifyGridContainsText("Option Trade");
     }
 
@@ -52,13 +54,14 @@ public class ManualEntryTests : PlaywrightTestBase
         await NavigateAndWaitForBlazorAsync(PagePath);
         await SelectEntryType("Future Contract");
         await WaitForTextAsync("Add Future Contract Trade");
+        int preCount = await GetCurrentGridRowCount();
 
         await FillComboBox("Enter ticker or asset name", "ES-TEST");
         await FillMoneyAmountByTitle("Contract Value", "5000");
 
         await ClickButtonByText("Add Future Trade");
         await VerifySuccessToast("added");
-        await VerifyGridRowCount(1);
+        await VerifyGridRowCount(preCount + 1);
         await VerifyGridContainsText("Future Contract");
     }
 
@@ -68,6 +71,7 @@ public class ManualEntryTests : PlaywrightTestBase
         await NavigateAndWaitForBlazorAsync(PagePath);
         await SelectEntryType("FX Trade");
         await WaitForTextAsync("Add FX Trade");
+        int preCount = await GetCurrentGridRowCount();
 
         // FX Trade defaults asset name to "USD"
         await FillNumericByLabel("Quantity", "1000");
@@ -75,7 +79,7 @@ public class ManualEntryTests : PlaywrightTestBase
 
         await ClickButtonByText("Add FX Trade");
         await VerifySuccessToast("added");
-        await VerifyGridRowCount(1);
+        await VerifyGridRowCount(preCount + 1);
         await VerifyGridContainsText("FX Trade");
     }
 
@@ -85,13 +89,14 @@ public class ManualEntryTests : PlaywrightTestBase
         await NavigateAndWaitForBlazorAsync(PagePath);
         await SelectEntryType("Dividend");
         await WaitForTextAsync("Add Dividend");
+        int preCount = await GetCurrentGridRowCount();
 
         await FillComboBox("Enter ticker or asset name", "MSFT-TEST");
         await FillMoneyAmountByTitle("Amount", "50");
 
         await ClickButtonByText("Add Dividend");
         await VerifySuccessToast("added");
-        await VerifyGridRowCount(1);
+        await VerifyGridRowCount(preCount + 1);
         await VerifyGridContainsText("MSFT-TEST");
     }
 
@@ -101,13 +106,14 @@ public class ManualEntryTests : PlaywrightTestBase
         await NavigateAndWaitForBlazorAsync(PagePath);
         await SelectEntryType("Interest Income");
         await WaitForTextAsync("Add Interest Income");
+        int preCount = await GetCurrentGridRowCount();
 
         await FillComboBox("Enter ticker or asset name", "SAVINGS-TEST");
         await FillMoneyAmountByTitle("Amount", "100");
 
         await ClickButtonByText("Add Interest Income");
         await VerifySuccessToast("added");
-        await VerifyGridRowCount(1);
+        await VerifyGridRowCount(preCount + 1);
         await VerifyGridContainsText("SAVINGS-TEST");
     }
 
@@ -239,6 +245,36 @@ public class ManualEntryTests : PlaywrightTestBase
         TestContext.WriteLine($"Grid row count: {count}");
         Assert.That(count, Is.EqualTo(expectedCount),
             $"Expected {expectedCount} rows in the Added Entries grid, but found {count}");
+    }
+
+    /// <summary>
+    /// Gets the current number of data rows in the Added Entries grid.
+    /// </summary>
+    private async Task<int> GetCurrentGridRowCount()
+    {
+        // The section can render either:
+        // 1) an empty-state alert (no grid), or
+        // 2) the Syncfusion grid with rows.
+        // Poll until one of the states appears, then return the baseline row count.
+        var emptyState = Page.Locator(".alert:has-text('No entries have been added on this page yet.')").First;
+        var grid = Page.Locator(".e-grid").First;
+
+        for (int i = 0; i < 20; i++)
+        {
+            if (await emptyState.CountAsync() > 0 && await emptyState.IsVisibleAsync())
+            {
+                return 0;
+            }
+
+            if (await grid.CountAsync() > 0 && await grid.IsVisibleAsync())
+            {
+                return await Page.Locator(".e-grid .e-row").CountAsync();
+            }
+
+            await Task.Delay(500);
+        }
+
+        throw new TimeoutException("Timed out waiting for either empty-state alert or added-entries grid to appear.");
     }
 
     /// <summary>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive manual-entry forms for stocks, options, futures, FX trades, dividends, and interest income with add/edit workflows and post-add callbacks.
  * New reusable amount/currency/FX row, common date/asset fields, and an AssetName selector with configurable manual input and asset-type filtering.
  * New manual-entry tracking service to track session entries.

* **UI/UX**
  * Menu label changed to "Add Manual Entries", new styling for manual-entry sections, dynamic form rendering, in-session edit/delete and live session grid.

* **Tests**
  * Added end-to-end Playwright tests covering all manual entry workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->