### PR TITLE
Include ETF dividend income in interest summaries, exports and PDF; add tests

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Model/DividendSummary.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/DividendSummary.cs
@@ -41,7 +41,11 @@ public record DividendSummary
     public virtual WrappedMoney TotalExcessReportableIncomeInterest => (from interest in RelatedInterestIncome
                                                                         where interest.InterestType is InterestType.EXCESSREPORTABLEINCOME
                                                                         select interest.Amount.BaseCurrencyAmount).Sum();
+    public virtual WrappedMoney TotalEtfDividendIncome => (from interest in RelatedInterestIncome
+                                                           where interest.InterestType is InterestType.ETFDIVIDEND
+                                                           select interest.Amount.BaseCurrencyAmount).Sum();
 
-    public virtual WrappedMoney TotalInterestIncome => TotalTaxableSavingInterest + TotalTaxableBondInterest + TotalAccurredIncomeProfit + TotalAccurredIncomeLoss + TotalExcessReportableIncomeInterest;
+    public virtual WrappedMoney TotalInterestIncome => (from interest in RelatedInterestIncome
+                                                        select interest.Amount.BaseCurrencyAmount).Sum();
 
 }

--- a/BlazorApp-Investment Tax Calculator/Services/DividendExportService.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/DividendExportService.cs
@@ -26,6 +26,7 @@ public class DividendExportService(DividendCalculationResult dividendCalculation
             output.AppendLine($"\tBond interest: {dividendSummary.TotalTaxableBondInterest}");
             output.AppendLine($"\tAccrued income profit: {dividendSummary.TotalAccurredIncomeProfit}");
             output.AppendLine($"\tAccrued income loss: {dividendSummary.TotalAccurredIncomeLoss}");
+            output.AppendLine($"\tETF dividend income: {dividendSummary.TotalEtfDividendIncome}");
             output.AppendLine($"\tExcess Reportable Income (Interest): {dividendSummary.TotalExcessReportableIncomeInterest}");
             output.AppendLine($"\tTotal interest income: {dividendSummary.TotalInterestIncome}\n");
             output.AppendLine();

--- a/BlazorApp-Investment Tax Calculator/Services/PdfExport/Sections/InterestIncomeSummarySection.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/PdfExport/Sections/InterestIncomeSummarySection.cs
@@ -29,6 +29,7 @@ public class InterestIncomeSummarySection(DividendCalculationResult incomeCalcul
             (15, ParagraphAlignment.Right),
             (15, ParagraphAlignment.Right),
             (15, ParagraphAlignment.Right),
+            (15, ParagraphAlignment.Right),
             (15, ParagraphAlignment.Right)]);
 
         Row headerRow = table.AddRow();
@@ -38,8 +39,9 @@ public class InterestIncomeSummarySection(DividendCalculationResult incomeCalcul
         headerRow.Cells[2].AddParagraph("Saving interest received");
         headerRow.Cells[3].AddParagraph("Income profit accurred");
         headerRow.Cells[4].AddParagraph("Income loss accurred");
-        headerRow.Cells[5].AddParagraph("ERI interest");
-        headerRow.Cells[6].AddParagraph("Total interest income taxible");
+        headerRow.Cells[5].AddParagraph("ETF dividend income");
+        headerRow.Cells[6].AddParagraph("ERI interest");
+        headerRow.Cells[7].AddParagraph("Total interest income taxable");
 
         foreach (var summary in incomeSummaries)
         {
@@ -49,8 +51,9 @@ public class InterestIncomeSummarySection(DividendCalculationResult incomeCalcul
             row.Cells[2].AddParagraph(summary.TotalTaxableSavingInterest.ToString());
             row.Cells[3].AddParagraph(summary.TotalAccurredIncomeProfit.ToString());
             row.Cells[4].AddParagraph(summary.TotalAccurredIncomeLoss.ToString());
-            row.Cells[5].AddParagraph(summary.TotalExcessReportableIncomeInterest.ToString());
-            row.Cells[6].AddParagraph(summary.TotalInterestIncome.ToString());
+            row.Cells[5].AddParagraph(summary.TotalEtfDividendIncome.ToString());
+            row.Cells[6].AddParagraph(summary.TotalExcessReportableIncomeInterest.ToString());
+            row.Cells[7].AddParagraph(summary.TotalInterestIncome.ToString());
         }
 
         foreach (var summary in incomeSummaries)

--- a/UnitTest/Test/Model/DividendSummaryTest.cs
+++ b/UnitTest/Test/Model/DividendSummaryTest.cs
@@ -1,0 +1,48 @@
+using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model.TaxEvents;
+
+namespace UnitTest.Test.Model;
+
+public class DividendSummaryTest
+{
+    [Fact]
+    public void TotalInterestIncome_IncludesEtfDividendIncome()
+    {
+        DividendSummary summary = new()
+        {
+            CountryOfOrigin = CountryCode.GetRegionByTwoDigitCode("GB"),
+            TaxYear = 2024,
+            RelatedDividendsAndTaxes = [],
+            RelatedInterestIncome =
+            [
+                new InterestIncome { AssetName = "ETF-1", Date = new DateTime(2025, 1, 1), InterestType = InterestType.SAVINGS, Amount = new DescribedMoney(10m, "GBP", 1m) },
+                new InterestIncome { AssetName = "ETF-1", Date = new DateTime(2025, 1, 2), InterestType = InterestType.BOND, Amount = new DescribedMoney(20m, "GBP", 1m) },
+                new InterestIncome { AssetName = "ETF-1", Date = new DateTime(2025, 1, 3), InterestType = InterestType.ACCURREDINCOMEPROFIT, Amount = new DescribedMoney(30m, "GBP", 1m) },
+                new InterestIncome { AssetName = "ETF-1", Date = new DateTime(2025, 1, 4), InterestType = InterestType.ACCURREDINCOMELOSS, Amount = new DescribedMoney(-5m, "GBP", 1m) },
+                new InterestIncome { AssetName = "ETF-1", Date = new DateTime(2025, 1, 5), InterestType = InterestType.EXCESSREPORTABLEINCOME, Amount = new DescribedMoney(40m, "GBP", 1m) },
+                new InterestIncome { AssetName = "ETF-1", Date = new DateTime(2025, 1, 6), InterestType = InterestType.ETFDIVIDEND, Amount = new DescribedMoney(50m, "GBP", 1m) }
+            ]
+        };
+
+        summary.TotalInterestIncome.ShouldBe(new WrappedMoney(145m));
+    }
+
+    [Fact]
+    public void TotalInterestIncome_IncludesAllInterestEntries_EvenIfTypeIsNew()
+    {
+        DividendSummary summary = new()
+        {
+            CountryOfOrigin = CountryCode.GetRegionByTwoDigitCode("GB"),
+            TaxYear = 2024,
+            RelatedDividendsAndTaxes = [],
+            RelatedInterestIncome =
+            [
+                new InterestIncome { AssetName = "Known", Date = new DateTime(2025, 1, 1), InterestType = InterestType.SAVINGS, Amount = new DescribedMoney(10m, "GBP", 1m) },
+                new InterestIncome { AssetName = "FutureType", Date = new DateTime(2025, 1, 2), InterestType = (InterestType)999, Amount = new DescribedMoney(7m, "GBP", 1m) }
+            ]
+        };
+
+        summary.TotalInterestIncome.ShouldBe(new WrappedMoney(17m));
+    }
+}

--- a/UnitTest/Test/Services/DividendExportServiceTest.cs
+++ b/UnitTest/Test/Services/DividendExportServiceTest.cs
@@ -1,0 +1,58 @@
+using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Services;
+
+namespace UnitTest.Test.Services;
+
+public class DividendExportServiceTest
+{
+    [Fact]
+    public void Export_IncludesEtfDividendIncomeLine_AndAddsItToTotalInterestIncome()
+    {
+        DividendSummary summary = new()
+        {
+            CountryOfOrigin = CountryCode.GetRegionByTwoDigitCode("GB"),
+            TaxYear = 2024,
+            RelatedDividendsAndTaxes = [],
+            RelatedInterestIncome =
+            [
+                new InterestIncome { AssetName = "ETF-1", Date = new DateTime(2025, 1, 1), InterestType = InterestType.SAVINGS, Amount = new DescribedMoney(5m, "GBP", 1m) },
+                new InterestIncome { AssetName = "ETF-1", Date = new DateTime(2025, 1, 2), InterestType = InterestType.ETFDIVIDEND, Amount = new DescribedMoney(25m, "GBP", 1m) }
+            ]
+        };
+
+        DividendCalculationResult result = new();
+        result.SetResult([summary]);
+        DividendExportService service = new(result);
+
+        string output = service.Export([2024]);
+
+        output.ShouldContain("ETF dividend income: £25.00");
+        output.ShouldContain("Total interest income: £30.00");
+    }
+
+    [Fact]
+    public void Export_PrintsZeroForEtfDividendIncome_WhenNoEtfDividendEvents()
+    {
+        DividendSummary summary = new()
+        {
+            CountryOfOrigin = CountryCode.GetRegionByTwoDigitCode("GB"),
+            TaxYear = 2024,
+            RelatedDividendsAndTaxes = [],
+            RelatedInterestIncome =
+            [
+                new InterestIncome { AssetName = "Cash-1", Date = new DateTime(2025, 2, 1), InterestType = InterestType.SAVINGS, Amount = new DescribedMoney(12m, "GBP", 1m) }
+            ]
+        };
+
+        DividendCalculationResult result = new();
+        result.SetResult([summary]);
+        DividendExportService service = new(result);
+
+        string output = service.Export([2024]);
+
+        output.ShouldContain("ETF dividend income: £0.00");
+        output.ShouldContain("Total interest income: £12.00");
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure ETF dividend events are included in interest reporting and totals so ETF distributions are visible in exports and PDFs.
- Make `TotalInterestIncome` resilient to new or future `InterestType` values by deriving the total from all interest entries instead of a fixed set of types.
- Add unit tests to prevent regressions and verify the new field appears in text export output and contributes to totals.

### Description

- Added a new `TotalEtfDividendIncome` property to `DividendSummary` that aggregates `InterestType.ETFDIVIDEND` amounts. 
- Changed `TotalInterestIncome` in `DividendSummary` to sum `Amount.BaseCurrencyAmount` across all `RelatedInterestIncome` entries instead of adding a fixed subset of types. 
- Updated `DividendExportService` to print an "ETF dividend income" line and use the new total calculation when exporting text. 
- Updated the PDF section `InterestIncomeSummarySection` to add a column for ETF dividend income and adjust header/row indices accordingly. 
- Added unit tests `DividendSummaryTest` and `DividendExportServiceTest` to validate inclusion of ETF dividend entries in totals and exported text.

### Testing

- Ran the unit test suite with `dotnet test`, which included `DividendSummaryTest` and `DividendExportServiceTest`, and all tests passed. 
- Tests verify that `TotalInterestIncome` includes `ETFDIVIDEND` values and that `DividendExportService.Export` prints the ETF line and produces the expected totals. 
- No automated failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ee47899c832f95d4a148af91cf4f)