### PR TITLE
Load IB XML test fixtures via AppContext.BaseDirectory to fix resource path failures

### DIFF
--- a/UnitTest/Test/Parser/IBXmlParseControllerTest.cs
+++ b/UnitTest/Test/Parser/IBXmlParseControllerTest.cs
@@ -5,8 +5,8 @@ namespace UnitTest.Test.Parser;
 
 public class IBXmlParseControllerTest
 {
-    private readonly string _taxExampleXml = File.ReadAllText(@".\Test\Resource\TaxExample.xml");
-    private readonly string _invalidFileXml = File.ReadAllText(@".\Test\Resource\InvalidFile.xml");
+    private readonly string _taxExampleXml = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Test", "resource", "TaxExample.xml"));
+    private readonly string _invalidFileXml = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Test", "resource", "InvalidFile.xml"));
 
     [Fact]
     public void TestCheckingInvalidIBXml()

--- a/UnitTest/Test/Parser/IBXmlParseTest.cs
+++ b/UnitTest/Test/Parser/IBXmlParseTest.cs
@@ -10,7 +10,7 @@ namespace UnitTest.Test.Parser;
 
 public class IBXmlParseTest
 {
-    private readonly XElement _xmlDoc = XElement.Load(@".\Test\Resource\TaxExample.xml");
+    private readonly XElement _xmlDoc = XElement.Load(Path.Combine(AppContext.BaseDirectory, "Test", "resource", "TaxExample.xml"));
 
     [Fact]
     public void TestReadingIBXmlDividends()


### PR DESCRIPTION
### Motivation
- Unit tests for the Interactive Brokers XML parser were failing in this environment due to Windows-style relative paths and casing mismatches pointing at `Test\Resource\...` which do not resolve on Linux/CI test runs.

### Description
- Updated `IBXmlParseControllerTest` to read fixtures with `File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Test", "resource", "<file>.xml"))` instead of a Windows relative string.
- Updated `IBXmlParseTest` to load the XML document using `XElement.Load(Path.Combine(AppContext.BaseDirectory, "Test", "resource", "TaxExample.xml"))` for a portable path resolution.
- Aligned the tests to use the repository folder name casing `resource` so the files are discovered when copied to the test output directory.

### Testing
- Ran `dotnet test UnitTest/UnitTest.csproj -v minimal` before the changes and the run failed with missing resource errors (multiple `FileNotFoundException`/`DirectoryNotFoundException`).
- Ran `dotnet test UnitTest/UnitTest.csproj -v minimal` after the changes and all unit tests passed (`Passed: 281, Failed: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90e195360832fa516e05c086f45fe)