### PR TITLE
Add Ticker Rename corporate action (model, UI, tests)

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Components/TickerRename.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/TickerRename.razor
@@ -1,0 +1,137 @@
+@using InvestmentTaxCalculator.Model.Interfaces
+@using InvestmentTaxCalculator.Model.TaxEvents
+@using InvestmentTaxCalculator.Services
+@using Syncfusion.Blazor.Buttons
+
+@inject ITradeAndCorporateActionList _taxEventLists
+@inject ToastService _toastService
+
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-content-center">
+        <h3>@(_isEditing ? "Edit" : "Record") Ticker Rename</h3>
+        @if (_isEditing)
+        {
+            <SfButton CssClass="e-flat e-small" OnClick="CancelEdit">Cancel Edit</SfButton>
+        }
+    </div>
+    <div class="card-body">
+        <CorporateActionHeader @bind-Date="@_date"
+                               @bind-SourceTicker="@_oldTicker"
+                               @bind-DestinationTicker="@_newTicker"
+                               @bind-SourceRatio="@_fixedRatio"
+                               @bind-DestinationRatio="@_fixedRatio"
+                               SourceLabel="Old Ticker"
+                               DestinationLabel="New Ticker"
+                               RatioLabel="Transition Ratio"
+                               SourceUnitLabel="old ticker shares"
+                               DestinationUnitLabel="new ticker shares"
+                               RatioDecimals="0"
+                               RatioFormat="n0"
+                               RatioMin="1m"
+                               IsDestinationDisabled="false" />
+
+        <div class="alert alert-info">
+            This action fully transfers the Section 104 pool from the old ticker to the new ticker on the event date. It does not create an acquisition.
+        </div>
+
+        <div class="row">
+            <div class="col-12">
+                <SfButton IsPrimary="true" OnClick="Submit">@(_isEditing ? "Update" : "Add") Ticker Rename</SfButton>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback OnCorporateActionAdded { get; set; }
+    [Parameter] public TickerRenameCorporateAction? ActionToEdit { get; set; }
+
+    private DateTime _date = DateTime.Today;
+    private string? _oldTicker;
+    private string? _newTicker;
+    private decimal _fixedRatio = 1m;
+    private bool _isEditing => ActionToEdit != null;
+    private TickerRenameCorporateAction? _previousActionToEdit;
+
+    protected override void OnInitialized()
+    {
+        if (ActionToEdit != null)
+        {
+            LoadAction(ActionToEdit);
+        }
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (ActionToEdit != null)
+        {
+            if (!ReferenceEquals(ActionToEdit, _previousActionToEdit))
+            {
+                LoadAction(ActionToEdit);
+            }
+        }
+        else if (_previousActionToEdit != null)
+        {
+            _previousActionToEdit = null;
+        }
+    }
+
+    private void LoadAction(TickerRenameCorporateAction action)
+    {
+        _date = action.Date;
+        _oldTicker = action.AssetName;
+        _newTicker = action.NewTicker;
+        _previousActionToEdit = action;
+    }
+
+    private async Task CancelEdit()
+    {
+        _oldTicker = null;
+        _newTicker = null;
+        _previousActionToEdit = null;
+        ActionToEdit = null;
+        await OnCorporateActionAdded.InvokeAsync();
+    }
+
+    private async Task Submit()
+    {
+        if (string.IsNullOrWhiteSpace(_oldTicker))
+        {
+            _toastService.ShowError("Please select the old ticker.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_newTicker))
+        {
+            _toastService.ShowError("Please enter the new ticker.");
+            return;
+        }
+
+        if (_oldTicker == _newTicker)
+        {
+            _toastService.ShowError("Old and new tickers cannot be the same.");
+            return;
+        }
+
+        var action = new TickerRenameCorporateAction
+        {
+            Date = _date,
+            AssetName = _oldTicker,
+            NewTicker = _newTicker
+        };
+
+        if (_isEditing)
+        {
+            bool removed = _taxEventLists.CorporateActions.Remove(ActionToEdit!);
+            if (!removed)
+            {
+                _toastService.ShowWarning("Unable to update ticker rename because the original entry could not be found.");
+                return;
+            }
+        }
+
+        _taxEventLists.CorporateActions.Add(action);
+        _toastService.ShowInformation(_isEditing ? "Ticker rename updated successfully." : "Ticker rename added successfully.");
+        await OnCorporateActionAdded.InvokeAsync();
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Model/TaxEvents/CorporateAction.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TaxEvents/CorporateAction.cs
@@ -15,6 +15,7 @@ namespace InvestmentTaxCalculator.Model.TaxEvents;
 [JsonDerivedType(typeof(ReturnOfCapitalCorporateAction), "roc")]
 [JsonDerivedType(typeof(SpinoffCorporateAction), "spinoff")]
 [JsonDerivedType(typeof(PartnerTransferCorporateAction), "partnerTransfer")]
+[JsonDerivedType(typeof(TickerRenameCorporateAction), "tickerRename")]
 public abstract record CorporateAction : TaxEvent
 {
     [JsonIgnore]

--- a/BlazorApp-Investment Tax Calculator/Model/TaxEvents/TickerRenameCorporateAction.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TaxEvents/TickerRenameCorporateAction.cs
@@ -1,0 +1,77 @@
+using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model.Interfaces;
+using InvestmentTaxCalculator.Model.UkTaxModel;
+using InvestmentTaxCalculator.Model.UkTaxModel.Stocks;
+
+namespace InvestmentTaxCalculator.Model.TaxEvents;
+
+/// <summary>
+/// Represents a corporate ticker rename where holdings move from an old ticker to a new ticker
+/// without creating an acquisition or disposal.
+/// </summary>
+public record TickerRenameCorporateAction : CorporateAction, IChangeSection104
+{
+    public override IReadOnlyList<string> CompanyTickersInProcessingOrder => [AssetName, NewTicker];
+
+    public required string NewTicker { get; init; }
+
+    public override string Reason => $"Ticker rename from {AssetName} to {NewTicker} on {Date:d}";
+
+    public override AssetCategoryType AppliesToAssetCategoryType { get; } = AssetCategoryType.STOCK;
+
+    private decimal _transferQuantity;
+    private WrappedMoney _transferCost = WrappedMoney.GetBaseCurrencyZero();
+
+    public override MatchAdjustment TradeMatching(ITradeTaxCalculation trade1, ITradeTaxCalculation trade2, MatchAdjustment matchAdjustment)
+    {
+        return matchAdjustment;
+    }
+
+    public override void ChangeSection104(UkSection104 section104)
+    {
+        if (AssetName == section104.AssetName)
+        {
+            ProcessOldTicker(section104);
+        }
+        else if (NewTicker == section104.AssetName)
+        {
+            ProcessNewTicker(section104);
+        }
+    }
+
+    private void ProcessOldTicker(UkSection104 section104)
+    {
+        _transferQuantity = 0m;
+        _transferCost = WrappedMoney.GetBaseCurrencyZero();
+
+        decimal oldQuantity = section104.Quantity;
+        WrappedMoney oldCost = section104.AcquisitionCostInBaseCurrency;
+
+        if (oldQuantity == 0m)
+        {
+            return;
+        }
+
+        _transferQuantity = oldQuantity;
+        _transferCost = oldCost;
+
+        string explanation = $"Ticker renamed to {NewTicker} on {Date:d}. Pool transferred to new ticker.";
+        section104.ClearSection104(Date, explanation);
+    }
+
+    private void ProcessNewTicker(UkSection104 section104)
+    {
+        if (_transferQuantity == 0m)
+        {
+            return;
+        }
+
+        string explanation = $"Ticker rename from {AssetName} on {Date:d}: {_transferQuantity:0.####} shares moved with cost basis {_transferCost}.";
+        section104.AddAssets(Date, _transferQuantity, _transferCost, null, explanation);
+    }
+
+    public override string GetDuplicateSignature()
+    {
+        return $"TICKERRENAME|{base.GetDuplicateSignature()}|{NewTicker}";
+    }
+}

--- a/BlazorApp-Investment Tax Calculator/Pages/TakeoverCorporateActionPage.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/TakeoverCorporateActionPage.razor
@@ -47,6 +47,10 @@
                 {
                     <StockSplit OnCorporateActionAdded="OnActionModified" ActionToEdit="@(_actionToEdit as StockSplitAction)" />
                 }
+                else if (_selectedAction == "Ticker Rename")
+                {
+                    <TickerRename OnCorporateActionAdded="OnActionModified" ActionToEdit="@(_actionToEdit as TickerRenameCorporateAction)" />
+                }
                 else if (_selectedAction == "Gift to partner")
                 {
                     <PartnerTransfer Direction="PartnerTransferDirection.GiftToPartner"
@@ -79,7 +83,7 @@
     private IDisposable? _navigationRegistration;
     private static readonly List<AssetCategoryType> _stockAssetCategoryFilter = [AssetCategoryType.STOCK];
     
-    private List<string> _actionTypes = new() { "Takeover / Merger", "Spinoff", "Stock Split / Reverse Split", "Gift to partner", "Receive from partner" };
+    private List<string> _actionTypes = new() { "Takeover / Merger", "Spinoff", "Stock Split / Reverse Split", "Ticker Rename", "Gift to partner", "Receive from partner" };
     private string? _selectedAction = "Takeover / Merger";
 
     private CorporateAction? _actionToEdit;
@@ -111,6 +115,9 @@
                 break;
             case StockSplitAction:
                 _selectedAction = "Stock Split / Reverse Split";
+                break;
+            case TickerRenameCorporateAction:
+                _selectedAction = "Ticker Rename";
                 break;
             case PartnerTransferCorporateAction partner:
                 _selectedAction = partner.Direction == PartnerTransferDirection.GiftToPartner ? "Gift to partner" : "Receive from partner";

--- a/UnitTest/Test/Model/TickerRenameCorporateActionTest.cs
+++ b/UnitTest/Test/Model/TickerRenameCorporateActionTest.cs
@@ -1,0 +1,60 @@
+using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Model.UkTaxModel;
+using InvestmentTaxCalculator.Model.UkTaxModel.Stocks;
+
+using UnitTest.Helper;
+
+namespace UnitTest.Test.Model;
+
+public class TickerRenameCorporateActionTest
+{
+    [Fact]
+    public void TickerRename_ShouldMoveEntireSection104PoolFromOldTickerToNewTicker()
+    {
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("FB", new DateTime(2021, 1, 1), 100, 1500m, TradeType.ACQUISITION);
+
+        UkSection104 oldTickerSection104 = new("FB");
+        UkSection104 newTickerSection104 = new("META");
+        buyTrade.MatchWithSection104(oldTickerSection104);
+
+        TickerRenameCorporateAction action = new()
+        {
+            AssetName = "FB",
+            Date = new DateTime(2022, 6, 9),
+            NewTicker = "META"
+        };
+
+        action.ChangeSection104(oldTickerSection104);
+        action.ChangeSection104(newTickerSection104);
+
+        oldTickerSection104.Quantity.ShouldBe(0m);
+        oldTickerSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(0m));
+
+        newTickerSection104.Quantity.ShouldBe(100m);
+        newTickerSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(1500m));
+        newTickerSection104.Section104HistoryList[^1].Explanation.ShouldContain("Ticker rename from FB");
+    }
+
+    [Fact]
+    public void TickerRename_WhenNoOldTickerHolding_ShouldNotCreateNewPoolEntry()
+    {
+        UkSection104 oldTickerSection104 = new("AOL");
+        UkSection104 newTickerSection104 = new("TWX");
+
+        TickerRenameCorporateAction action = new()
+        {
+            AssetName = "AOL",
+            Date = new DateTime(2003, 10, 16),
+            NewTicker = "TWX"
+        };
+
+        action.ChangeSection104(oldTickerSection104);
+        action.ChangeSection104(newTickerSection104);
+
+        oldTickerSection104.Quantity.ShouldBe(0m);
+        newTickerSection104.Quantity.ShouldBe(0m);
+        newTickerSection104.Section104HistoryList.Count.ShouldBe(0);
+    }
+}


### PR DESCRIPTION
### Motivation
- Support corporate ticker renames (e.g. FB -> META) that transfer Section 104 pools from an old ticker to a new ticker without creating an acquisition or disposal.

### Description
- Add `TickerRenameCorporateAction` model that implements `IChangeSection104` and performs a two-phase transfer: clear the old ticker S104 pool (remember quantity and cost) then add the same quantity and cost to the new ticker pool; the action does not count as an acquisition. (file: `Model/TaxEvents/TickerRenameCorporateAction.cs`)
- Register the new action in JSON polymorphic serialization by adding a `JsonDerivedType` entry so renames persist/load with other corporate actions. (file: `Model/TaxEvents/CorporateAction.cs`)
- Add a Blazor UI component `TickerRename.razor` to record/edit ticker renames with validation for date, old ticker and new ticker, and wire it into the corporate actions selector and edit routing on the corporate actions page. (files: `Components/TickerRename.razor`, `Pages/TakeoverCorporateActionPage.razor`)
- Add unit tests covering full-pool transfer and the no-op case when the old ticker has no holdings. (file: `UnitTest/Test/Model/TickerRenameCorporateActionTest.cs`)

### Testing
- Ran unit tests with `dotnet test UnitTest/UnitTest.csproj --no-restore`, and the suite passed: `Passed 283, Failed 0`.
- Only unit tests were executed (Playwright tests were not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91736617c832fb714a1a832442808)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ticker Rename corporate action: Record and edit ticker symbol changes for your holdings. Automatically transfers assets between tickers while preserving cost basis information without triggering disposal or acquisition events.

* **Tests**
  * Added comprehensive unit tests for ticker rename functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->