### PR TITLE
Implement gap period cost allocation for reporting fund events

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Components/EqualisationControl.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/EqualisationControl.razor
@@ -189,12 +189,27 @@
         var desMoney = new DescribedMoney(EqualisationAmount, Currency, FxRate, $"{eventTypeDesc} on {selectedEvent.Date:d}");
 
         // 1. Create FundEqualisation Corporate Action
+        // For ERI-related equalisation, record the reporting period end so units disposed of between the period end
+        // and the distribution date take their share of the cost reduction at the disposal instead of the pool.
+        DateTime? reportingPeriodEnd = null;
+        bool isEriEvent = selectedEvent is Dividend { DividendType: DividendType.EXCESS_REPORTABLE_INCOME }
+            or InterestIncome { InterestType: InterestType.EXCESSREPORTABLEINCOME };
+        if (isEriEvent)
+        {
+            var relatedEri = TaxEventLists.CorporateActions.OfType<ExcessReportableIncome>()
+                .FirstOrDefault(e => e.AssetName == SelectedTicker && e.Date == selectedEvent.Date);
+            reportingPeriodEnd = relatedEri is not null
+                ? relatedEri.EffectiveReportingPeriodEndDate.ToDateTime(TimeOnly.MinValue)
+                : selectedEvent.Date.AddMonths(-6);
+        }
+
         var equalisation = new FundEqualisation
         {
             AssetName = SelectedTicker,
             Date = selectedEvent.Date,
             Amount = desMoney,
-            RelatedEventDescription = desMoney.Description
+            RelatedEventDescription = desMoney.Description,
+            ReportingPeriodEndDate = reportingPeriodEnd
         };
 
         TaxEventLists.CorporateActions.Add(equalisation);

--- a/BlazorApp-Investment Tax Calculator/Components/EriControl.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/EriControl.razor
@@ -160,6 +160,7 @@
         {
             AssetName = SelectedTicker,
             Date = distributionDate,
+            ReportingPeriodEndDate = PeriodEndDate.Value,
             IncomeType = SelectedIncomeType,
             Amount = new DescribedMoney(totalAmountLocal, Currency, FxRate, $"ERI for {Quantity:N4} shares (Period End: {PeriodEndDate.Value:d})"),
             Isin = isin,

--- a/BlazorApp-Investment Tax Calculator/Model/TaxEvents/ExcessReportableIncome.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TaxEvents/ExcessReportableIncome.cs
@@ -3,6 +3,7 @@ using InvestmentTaxCalculator.Model.Interfaces;
 using InvestmentTaxCalculator.Model.UkTaxModel;
 
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 namespace InvestmentTaxCalculator.Model.TaxEvents;
 
@@ -28,6 +29,28 @@ public record ExcessReportableIncome : CorporateAction, IChangeSection104
     /// </summary>
     public CountryCode IncomeLocation { get; set; } = CountryCode.UnknownRegion;
 
+    /// <summary>
+    /// The last day of the fund reporting period this ERI relates to. Liability is fixed by the holding at the end
+    /// of this day (SI 2009/3001 reg. 94(3)). When absent (older saved files) it is assumed to be 6 months before
+    /// the fund distribution date, mirroring reg. 94(4).
+    /// </summary>
+    public DateTime? ReportingPeriodEndDate { get; init; }
+
+    [JsonIgnore]
+    public DateOnly EffectiveReportingPeriodEndDate => DateOnly.FromDateTime(ReportingPeriodEndDate ?? AssumedReportingPeriodEnd());
+
+    private DateTime AssumedReportingPeriodEnd()
+    {
+        DateTime assumed = Date.AddMonths(-6);
+        // Reg. 94(4) maps a month end period end to a month end distribution date (e.g. 31 Dec -> 30 Jun), so a
+        // month end distribution date is mapped back to the month end rather than AddMonths' clamped day.
+        if (Date.Day == DateTime.DaysInMonth(Date.Year, Date.Month))
+        {
+            assumed = new DateTime(assumed.Year, assumed.Month, DateTime.DaysInMonth(assumed.Year, assumed.Month));
+        }
+        return assumed;
+    }
+
     public override string Reason => $"{AssetName} excess reportable income ({IncomeType.GetDescription()}) of {Amount.BaseCurrencyAmount} on {Date:d}";
     public override AssetCategoryType AppliesToAssetCategoryType { get; } = AssetCategoryType.STOCK;
 
@@ -41,7 +64,9 @@ public record ExcessReportableIncome : CorporateAction, IChangeSection104
     {
         if (AssetName != section104.AssetName) return;
         string explanation = $"Excess reportable income ({IncomeType.GetDescription()}) of {Amount.BaseCurrencyAmount} on {Date:d}";
-        section104.AdjustAcquisitionCost(Amount.BaseCurrencyAmount, Date, explanation);
+        // The uplift is apportioned per unit held at the reporting period end: units disposed of in the gap period
+        // before the fund distribution date take their share at the disposal (reg. 99(5)), the rest goes to the pool.
+        ReportingFundCostAllocator.Apply(section104, EffectiveReportingPeriodEndDate, Date, Amount.BaseCurrencyAmount, explanation);
     }
     public override string GetDuplicateSignature()
     {

--- a/BlazorApp-Investment Tax Calculator/Model/TaxEvents/FundEqualisation.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TaxEvents/FundEqualisation.cs
@@ -20,6 +20,14 @@ public record FundEqualisation : CorporateAction, IChangeSection104
     /// </summary>
     public string? RelatedEventDescription { get; init; }
 
+    /// <summary>
+    /// The last day of the fund reporting period the related income event covers. When set, the cost reduction is
+    /// apportioned between units disposed of after this date but before the distribution date (adjusting those
+    /// disposals) and the retained section 104 pool. When null (older saved files or non-reporting fund income)
+    /// the whole amount reduces the pool on the distribution date, as before.
+    /// </summary>
+    public DateTime? ReportingPeriodEndDate { get; init; }
+
     public override string Reason => $"{AssetName} fund equalisation of {Amount.BaseCurrencyAmount} on {Date:d}" + (string.IsNullOrEmpty(RelatedEventDescription) ? "" : $" ({RelatedEventDescription})");
 
     public override AssetCategoryType AppliesToAssetCategoryType { get; } = AssetCategoryType.STOCK;
@@ -39,7 +47,14 @@ public record FundEqualisation : CorporateAction, IChangeSection104
             explanation += $" ({RelatedEventDescription})";
         }
         // Equalisation reduces the cost base, so we pass a negative adjustment
-        section104.AdjustAcquisitionCost(-Amount.BaseCurrencyAmount, Date, explanation);
+        if (ReportingPeriodEndDate is null)
+        {
+            section104.AdjustAcquisitionCost(-Amount.BaseCurrencyAmount, Date, explanation);
+            return;
+        }
+        // Units disposed of between the reporting period end and the distribution date take their share of the
+        // reduction at the disposal; only the retained units' share reduces the pool.
+        ReportingFundCostAllocator.Apply(section104, DateOnly.FromDateTime(ReportingPeriodEndDate.Value), Date, -Amount.BaseCurrencyAmount, explanation);
     }
     public override string GetDuplicateSignature()
     {

--- a/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/ReportingFundCostAllocator.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/ReportingFundCostAllocator.cs
@@ -30,47 +30,75 @@ public static class ReportingFundCostAllocator
             section104.AdjustAcquisitionCost(adjustmentAmount, adjustmentDate, description);
             return;
         }
+        // Both are tracked in the pool's current unit scale: quantity rescaling events (e.g. stock splits) in the
+        // gap period update the pair together so remaining * perUnit stays equal to the unallocated amount.
         WrappedMoney adjustmentPerUnit = adjustmentAmount / quantityAtPeriodEnd;
         decimal remainingPeriodEndUnits = quantityAtPeriodEnd;
-        List<Section104History> gapPeriodPoolDisposals = [.. section104.Section104HistoryList
-            .Where(history => DateOnly.FromDateTime(history.Date) > reportingPeriodEnd
-                              && history.QuantityChange < 0
-                              && history.TradeTaxCalculation is { AcquisitionDisposal: TradeType.DISPOSAL })];
-        foreach (Section104History history in gapPeriodPoolDisposals)
+        WrappedMoney unappliedAmount = WrappedMoney.GetBaseCurrencyZero();
+
+        List<Section104History> gapPeriodQuantityChanges = [.. section104.Section104HistoryList
+            .Where(history => DateOnly.FromDateTime(history.Date) > reportingPeriodEnd && history.QuantityChange != 0)];
+        foreach (Section104History history in gapPeriodQuantityChanges)
         {
             if (remainingPeriodEndUnits <= 0) break;
-            // The section 104 pool is fungible, so a pool disposal is treated as disposing of period end units in
-            // proportion to their share of the pool immediately before the disposal (just and reasonable apportionment).
-            decimal disposedQuantity = -history.QuantityChange;
-            decimal periodEndUnitsDisposed = history.OldQuantity > 0
-                ? Math.Min(remainingPeriodEndUnits, disposedQuantity * remainingPeriodEndUnits / history.OldQuantity)
+            if (history.TradeTaxCalculation is null && history.ValueChange.Amount == 0 && history.OldQuantity > 0 && history.NewQuantity > 0)
+            {
+                // Quantity rescaling (e.g. stock split): the same holding continues under a new unit count.
+                decimal rescaleFactor = history.NewQuantity / history.OldQuantity;
+                remainingPeriodEndUnits *= rescaleFactor;
+                adjustmentPerUnit /= rescaleFactor;
+                continue;
+            }
+            if (history.QuantityChange > 0) continue; // acquisitions dilute the pool but keep the period end units
+            // The section 104 pool is fungible, so a removal is treated as removing period end units in proportion
+            // to their share of the pool immediately before the removal (just and reasonable apportionment).
+            decimal removedQuantity = -history.QuantityChange;
+            decimal periodEndUnitsRemoved = history.OldQuantity > 0
+                ? Math.Min(remainingPeriodEndUnits, removedQuantity * remainingPeriodEndUnits / history.OldQuantity)
                 : 0m;
-            if (periodEndUnitsDisposed <= 0) continue;
-            TradeMatch? match = history.TradeTaxCalculation!.MatchHistory.FirstOrDefault(m => m.Section104HistorySnapshot == history);
-            // If the disposal match cannot be located the unallocated share stays with the pool remainder so no amount is lost.
-            if (match is null) continue;
-            WrappedMoney matchAdjustment = adjustmentPerUnit * periodEndUnitsDisposed;
-            match.BaseCurrencyMatchAllowableCost += matchAdjustment;
-            match.AdditionalInformation += $"{description}: allowable cost adjusted by {matchAdjustment} for {periodEndUnitsDisposed:0.####} unit(s) " +
-                $"held at the reporting period end {reportingPeriodEnd:d} and disposed of before the fund distribution date " +
-                $"(treated as received immediately before the disposal, SI 2009/3001 reg. 99(5)).\n";
-            remainingPeriodEndUnits -= periodEndUnitsDisposed;
+            if (periodEndUnitsRemoved <= 0) continue;
+            WrappedMoney removedUnitsShare = adjustmentPerUnit * periodEndUnitsRemoved;
+            TradeMatch? match = history.TradeTaxCalculation is { AcquisitionDisposal: TradeType.DISPOSAL } disposal
+                ? disposal.MatchHistory.FirstOrDefault(m => m.Section104HistorySnapshot == history)
+                : null;
+            if (match is not null)
+            {
+                match.BaseCurrencyMatchAllowableCost += removedUnitsShare;
+                match.AdditionalInformation += $"{description}: allowable cost adjusted by {removedUnitsShare} for {periodEndUnitsRemoved:0.####} unit(s) " +
+                    $"held at the reporting period end {reportingPeriodEnd:d} and disposed of before the fund distribution date " +
+                    $"(treated as received immediately before the disposal, SI 2009/3001 reg. 99(5)).\n";
+            }
+            else
+            {
+                // The units left the pool other than by a pool matched disposal (e.g. gift to partner, pool cleared
+                // by a corporate action): their share cannot uplift a disposal computation and must not inflate the
+                // cost of the retained units either, so it is only recorded.
+                unappliedAmount += removedUnitsShare;
+            }
+            remainingPeriodEndUnits -= periodEndUnitsRemoved;
         }
-        if (remainingPeriodEndUnits <= 0) return;
-        WrappedMoney poolAdjustment = adjustmentPerUnit * remainingPeriodEndUnits;
-        if (section104.Quantity > 0)
+
+        if (remainingPeriodEndUnits > 0)
         {
-            string poolExplanation = remainingPeriodEndUnits == quantityAtPeriodEnd
-                ? description
-                : $"{description} - {poolAdjustment} apportioned to the {remainingPeriodEndUnits:0.####} unit(s) retained after gap period disposal(s)";
-            section104.AdjustAcquisitionCost(poolAdjustment, adjustmentDate, poolExplanation);
+            WrappedMoney poolAdjustment = adjustmentPerUnit * remainingPeriodEndUnits;
+            if (section104.Quantity > 0)
+            {
+                string poolExplanation = remainingPeriodEndUnits == quantityAtPeriodEnd
+                    ? description
+                    : $"{description} - {poolAdjustment} apportioned to the {remainingPeriodEndUnits:0.####} unit(s) retained after gap period disposal(s)";
+                section104.AdjustAcquisitionCost(poolAdjustment, adjustmentDate, poolExplanation);
+            }
+            else
+            {
+                unappliedAmount += poolAdjustment;
+            }
         }
-        else
+        if (unappliedAmount.Amount != 0)
         {
-            // The pool is empty and no disposal can absorb the remainder (e.g. the units left the pool other than by
-            // disposal). Applying it would distort the cost of future unrelated acquisitions, so only record it.
+            // Record without changing the pool cost: applying it would distort the cost of units that never carried
+            // the entitlement (or of future unrelated acquisitions when the pool is empty).
             section104.AdjustAcquisitionCost(WrappedMoney.GetBaseCurrencyZero(), adjustmentDate,
-                $"{description} - {poolAdjustment} for {remainingPeriodEndUnits:0.####} unit(s) not applied: the section 104 pool is empty and no matching disposal was found.");
+                $"{description} - {unappliedAmount} attributable to unit(s) that left the section 104 pool other than by a matched disposal is not applied.");
         }
     }
 }

--- a/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/ReportingFundCostAllocator.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/ReportingFundCostAllocator.cs
@@ -1,0 +1,76 @@
+using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model.UkTaxModel.Stocks;
+
+namespace InvestmentTaxCalculator.Model.UkTaxModel;
+
+/// <summary>
+/// Splits a reporting fund cost adjustment (excess reportable income uplift or equalisation reduction) between
+/// disposals made in the "gap period" (after the end of the fund reporting period but before the fund distribution
+/// date) and the section 104 pool.
+/// Liability to the income is fixed by the holding at the end of the reporting period (SI 2009/3001 reg. 94(3)),
+/// so the adjustment is apportioned per unit held at the period end. The share belonging to units disposed of
+/// before the fund distribution date is applied to the allowable cost of those disposals (reg. 99(5) treats the
+/// amount as received immediately before the disposal), and only the retained units' share is applied to the
+/// section 104 pool on the fund distribution date (reg. 99(4)).
+/// </summary>
+public static class ReportingFundCostAllocator
+{
+    /// <summary>
+    /// Apply <paramref name="adjustmentAmount"/> (positive for an ERI base cost uplift, negative for an
+    /// equalisation base cost reduction) to the disposals in the gap period and the section 104 pool.
+    /// Must be called when the pool state reflects all events before <paramref name="adjustmentDate"/>,
+    /// which holds when invoked from ChangeSection104 as events are processed in chronological order.
+    /// </summary>
+    public static void Apply(UkSection104 section104, DateOnly reportingPeriodEnd, DateTime adjustmentDate, WrappedMoney adjustmentAmount, string description)
+    {
+        decimal quantityAtPeriodEnd = section104.GetLastSection104History(reportingPeriodEnd)?.NewQuantity ?? 0m;
+        if (quantityAtPeriodEnd <= 0)
+        {
+            // No holding recorded at the reporting period end - nothing to apportion, adjust the pool as a whole.
+            section104.AdjustAcquisitionCost(adjustmentAmount, adjustmentDate, description);
+            return;
+        }
+        WrappedMoney adjustmentPerUnit = adjustmentAmount / quantityAtPeriodEnd;
+        decimal remainingPeriodEndUnits = quantityAtPeriodEnd;
+        List<Section104History> gapPeriodPoolDisposals = [.. section104.Section104HistoryList
+            .Where(history => DateOnly.FromDateTime(history.Date) > reportingPeriodEnd
+                              && history.QuantityChange < 0
+                              && history.TradeTaxCalculation is { AcquisitionDisposal: TradeType.DISPOSAL })];
+        foreach (Section104History history in gapPeriodPoolDisposals)
+        {
+            if (remainingPeriodEndUnits <= 0) break;
+            // The section 104 pool is fungible, so a pool disposal is treated as disposing of period end units in
+            // proportion to their share of the pool immediately before the disposal (just and reasonable apportionment).
+            decimal disposedQuantity = -history.QuantityChange;
+            decimal periodEndUnitsDisposed = history.OldQuantity > 0
+                ? Math.Min(remainingPeriodEndUnits, disposedQuantity * remainingPeriodEndUnits / history.OldQuantity)
+                : 0m;
+            if (periodEndUnitsDisposed <= 0) continue;
+            TradeMatch? match = history.TradeTaxCalculation!.MatchHistory.FirstOrDefault(m => m.Section104HistorySnapshot == history);
+            // If the disposal match cannot be located the unallocated share stays with the pool remainder so no amount is lost.
+            if (match is null) continue;
+            WrappedMoney matchAdjustment = adjustmentPerUnit * periodEndUnitsDisposed;
+            match.BaseCurrencyMatchAllowableCost += matchAdjustment;
+            match.AdditionalInformation += $"{description}: allowable cost adjusted by {matchAdjustment} for {periodEndUnitsDisposed:0.####} unit(s) " +
+                $"held at the reporting period end {reportingPeriodEnd:d} and disposed of before the fund distribution date " +
+                $"(treated as received immediately before the disposal, SI 2009/3001 reg. 99(5)).\n";
+            remainingPeriodEndUnits -= periodEndUnitsDisposed;
+        }
+        if (remainingPeriodEndUnits <= 0) return;
+        WrappedMoney poolAdjustment = adjustmentPerUnit * remainingPeriodEndUnits;
+        if (section104.Quantity > 0)
+        {
+            string poolExplanation = remainingPeriodEndUnits == quantityAtPeriodEnd
+                ? description
+                : $"{description} - {poolAdjustment} apportioned to the {remainingPeriodEndUnits:0.####} unit(s) retained after gap period disposal(s)";
+            section104.AdjustAcquisitionCost(poolAdjustment, adjustmentDate, poolExplanation);
+        }
+        else
+        {
+            // The pool is empty and no disposal can absorb the remainder (e.g. the units left the pool other than by
+            // disposal). Applying it would distort the cost of future unrelated acquisitions, so only record it.
+            section104.AdjustAcquisitionCost(WrappedMoney.GetBaseCurrencyZero(), adjustmentDate,
+                $"{description} - {poolAdjustment} for {remainingPeriodEndUnits:0.####} unit(s) not applied: the section 104 pool is empty and no matching disposal was found.");
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://alexpung.github.io/UK-Investment-tax-calculator/
 3. Support trades and dividends in foreign currency.
 4. Support shorting and stock split corporate actions (forward and experimental support for reverse splits).
 5. Implementation of TCGA92/S105 (1)(a): Multiple trades in the same day for the same Buy/Sell side is treated as a single trade. This affect same day/bread and breakfast calculation.
-6. Support for **Excess Reportable Income (ERI) and Equalisation** for offshore funds/ETFs, including automatic cost base adjustment and region-based income reporting by detecting the ISIN country code.
+6. Support for **Excess Reportable Income (ERI) and Equalisation** for offshore funds/ETFs, including automatic cost base adjustment and region-based income reporting by detecting the ISIN country code. Units disposed of between the fund reporting period end and the fund distribution date take their share of the ERI/equalisation cost adjustment in the disposal computation (SI 2009/3001 reg. 99(5)); only the retained units' share is applied to the Section 104 pool on the fund distribution date (reg. 99(4)).
 7. Support for UK specific tax rules such as TCGA92/S122 for small distributions in corporate actions (automatic gain deferral).
 
 ## Supported import format and brokers

--- a/UnitTest/Test/Model/ExcessReportableIncomeTest.cs
+++ b/UnitTest/Test/Model/ExcessReportableIncomeTest.cs
@@ -46,4 +46,143 @@ public class ExcessReportableIncomeTest
         ukSection104.Section104HistoryList[1].ValueChange.ShouldBe(new WrappedMoney(50m));
         ukSection104.Section104HistoryList[1].Explanation.ShouldContain("Excess reportable income");
     }
+
+    [Fact]
+    public void TestGapPeriodPartialDisposalSplitsUpliftBetweenDisposalAndPool()
+    {
+        // Hold 1000 units at the reporting period end (31/12/2023), sell 400 in the gap period before the
+        // fund distribution date (30/6/2024). Reg. 99(5): the sold units' ERI uplifts the disposal base cost,
+        // only the retained units' share is added to the pool on the fund distribution date.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        TradeTaxCalculation sellTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2024, 4, 30), 400, 5000m, TradeType.DISPOSAL);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        sellTrade.MatchWithSection104(ukSection104);
+        sellTrade.Gain.ShouldBe(new WrappedMoney(1000m)); // 5000 - 4000 before the ERI uplift
+
+        ExcessReportableIncome eri = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            ReportingPeriodEndDate = new DateTime(2023, 12, 31),
+            IncomeType = ExcessReportableIncomeType.DIVIDEND,
+            Amount = new DescribedMoney(500m, "GBP", 1, "ERI") // 0.5 per unit for 1000 units held at period end
+        };
+        eri.ChangeSection104(ukSection104);
+
+        // Sold units: 400 * 0.5 = 200 added to the disposal allowable cost
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(4200m));
+        sellTrade.Gain.ShouldBe(new WrappedMoney(800m));
+        sellTrade.MatchHistory[0].AdditionalInformation.ShouldContain("reg. 99(5)");
+        // Retained units: 600 * 0.5 = 300 added to the pool
+        ukSection104.Quantity.ShouldBe(600m);
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(6300m));
+    }
+
+    [Fact]
+    public void TestGapPeriodFullDisposalLeavesPoolUntouched()
+    {
+        // Selling the whole holding in the gap period must send the entire uplift to the disposal and must not
+        // add cost to the now empty section 104 pool (which would distort future unrelated acquisitions).
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        TradeTaxCalculation sellTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2024, 4, 30), 1000, 14500m, TradeType.DISPOSAL);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        sellTrade.MatchWithSection104(ukSection104);
+
+        ExcessReportableIncome eri = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            ReportingPeriodEndDate = new DateTime(2023, 12, 31),
+            IncomeType = ExcessReportableIncomeType.DIVIDEND,
+            Amount = new DescribedMoney(500m, "GBP", 1, "ERI")
+        };
+        eri.ChangeSection104(ukSection104);
+
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(10500m));
+        sellTrade.Gain.ShouldBe(new WrappedMoney(4000m));
+        ukSection104.Quantity.ShouldBe(0m);
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(WrappedMoney.GetBaseCurrencyZero());
+    }
+
+    [Fact]
+    public void TestLegacyEriWithoutPeriodEndDefaultsToSixMonthsBeforeDistribution()
+    {
+        // Older saved files carry no reporting period end date; the period end is assumed to be 6 months before
+        // the fund distribution date (reg. 94(4)) so gap period disposals are still handled.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        TradeTaxCalculation sellTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2024, 4, 30), 400, 5000m, TradeType.DISPOSAL);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        sellTrade.MatchWithSection104(ukSection104);
+
+        ExcessReportableIncome eri = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            IncomeType = ExcessReportableIncomeType.DIVIDEND,
+            Amount = new DescribedMoney(500m, "GBP", 1, "ERI")
+        };
+        eri.EffectiveReportingPeriodEndDate.ShouldBe(new DateOnly(2023, 12, 31));
+        eri.ChangeSection104(ukSection104);
+
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(4200m));
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(6300m));
+    }
+
+    [Fact]
+    public void TestGapPeriodDisposalAfterFurtherAcquisitionIsApportionedProRata()
+    {
+        // 1000 units held at period end, 500 more bought in the gap period, then 600 sold from the fungible pool.
+        // The disposal is treated as disposing of period end units pro rata: 600 * 1000/1500 = 400 units.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        TradeTaxCalculation buyTrade2 = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2024, 2, 1), 500, 6000m, TradeType.ACQUISITION);
+        TradeTaxCalculation sellTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2024, 4, 30), 600, 9000m, TradeType.DISPOSAL);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        buyTrade2.MatchWithSection104(ukSection104);
+        sellTrade.MatchWithSection104(ukSection104);
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(6400m)); // 16000 * 600/1500
+
+        ExcessReportableIncome eri = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            ReportingPeriodEndDate = new DateTime(2023, 12, 31),
+            IncomeType = ExcessReportableIncomeType.DIVIDEND,
+            Amount = new DescribedMoney(500m, "GBP", 1, "ERI") // 0.5 per unit for the 1000 units held at period end
+        };
+        eri.ChangeSection104(ukSection104);
+
+        // Disposal takes 400 period end units * 0.5 = 200; pool keeps 600 period end units * 0.5 = 300
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(6600m));
+        ukSection104.Quantity.ShouldBe(900m);
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(9900m)); // 16000 - 6400 + 300
+    }
+
+    [Fact]
+    public void TestDisposalBeforePeriodEndDoesNotGetUplift()
+    {
+        // Units sold before the reporting period end are not held at the period end and carry no ERI.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        TradeTaxCalculation sellTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 11, 1), 400, 5000m, TradeType.DISPOSAL);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        sellTrade.MatchWithSection104(ukSection104);
+
+        ExcessReportableIncome eri = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            ReportingPeriodEndDate = new DateTime(2023, 12, 31),
+            IncomeType = ExcessReportableIncomeType.DIVIDEND,
+            Amount = new DescribedMoney(300m, "GBP", 1, "ERI") // 0.5 per unit for the 600 units held at period end
+        };
+        eri.ChangeSection104(ukSection104);
+
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(4000m)); // unchanged
+        ukSection104.Quantity.ShouldBe(600m);
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(6300m)); // 6000 + 300
+    }
 }

--- a/UnitTest/Test/Model/ExcessReportableIncomeTest.cs
+++ b/UnitTest/Test/Model/ExcessReportableIncomeTest.cs
@@ -222,6 +222,45 @@ public class ExcessReportableIncomeTest
     }
 
     [Fact]
+    public void TestGiftThenDisposalInGapPeriodDoesNotOverAttributeToDisposal()
+    {
+        // 1000 units at period end; 400 gifted to a partner, then 500 sold, both in the gap period. The disposal
+        // can only ever carry its own 500 units' share of the uplift (500 * 0.5 = 250), never more, because the
+        // gift already reduced the tracked period end units to 600 before the disposal is apportioned.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        PartnerTransferCorporateAction gift = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 2, 1),
+            Direction = PartnerTransferDirection.GiftToPartner,
+            Quantity = 400
+        };
+        gift.ChangeSection104(ukSection104);
+        TradeTaxCalculation sellTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2024, 4, 30), 500, 6000m, TradeType.DISPOSAL);
+        sellTrade.MatchWithSection104(ukSection104);
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(5000m)); // 6000 * 500/600
+
+        ExcessReportableIncome eri = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            ReportingPeriodEndDate = new DateTime(2023, 12, 31),
+            IncomeType = ExcessReportableIncomeType.DIVIDEND,
+            Amount = new DescribedMoney(500m, "GBP", 1, "ERI") // 0.5 per unit for 1000 units held at period end
+        };
+        eri.ChangeSection104(ukSection104);
+
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(5250m)); // + 500 units * 0.5, capped at the disposal size
+        // Pool keeps the retained 100 units' share; the gifted 400 units' 200 is recorded but not applied
+        ukSection104.Quantity.ShouldBe(100m);
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(1050m)); // 1000 + 100 * 0.5
+        ukSection104.Section104HistoryList.Last().ValueChange.ShouldBe(WrappedMoney.GetBaseCurrencyZero());
+        ukSection104.Section104HistoryList.Last().Explanation.ShouldContain("not applied");
+    }
+
+    [Fact]
     public void TestReverseSplitInGapPeriodStillAppliesFullUpliftToPool()
     {
         // A 1-for-2 reverse split in the gap period halves the unit count but the whole period end holding is

--- a/UnitTest/Test/Model/ExcessReportableIncomeTest.cs
+++ b/UnitTest/Test/Model/ExcessReportableIncomeTest.cs
@@ -185,4 +185,105 @@ public class ExcessReportableIncomeTest
         ukSection104.Quantity.ShouldBe(600m);
         ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(6300m)); // 6000 + 300
     }
+
+    [Fact]
+    public void TestGiftToPartnerInGapPeriodDoesNotInflateRetainedPool()
+    {
+        // 400 of the 1000 period end units are gifted to a partner in the gap period. Their share of the ERI
+        // cannot uplift a disposal and must not inflate the cost of the 600 retained units either.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        PartnerTransferCorporateAction gift = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 4, 30),
+            Direction = PartnerTransferDirection.GiftToPartner,
+            Quantity = 400
+        };
+        gift.ChangeSection104(ukSection104);
+        ukSection104.Quantity.ShouldBe(600m);
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(6000m));
+
+        ExcessReportableIncome eri = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            ReportingPeriodEndDate = new DateTime(2023, 12, 31),
+            IncomeType = ExcessReportableIncomeType.DIVIDEND,
+            Amount = new DescribedMoney(500m, "GBP", 1, "ERI") // 0.5 per unit for 1000 units held at period end
+        };
+        eri.ChangeSection104(ukSection104);
+
+        // Only the retained 600 units' share is applied; the gifted units' 200 is recorded but not applied
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(6300m));
+        ukSection104.Section104HistoryList.Last().ValueChange.ShouldBe(WrappedMoney.GetBaseCurrencyZero());
+        ukSection104.Section104HistoryList.Last().Explanation.ShouldContain("not applied");
+    }
+
+    [Fact]
+    public void TestReverseSplitInGapPeriodStillAppliesFullUpliftToPool()
+    {
+        // A 1-for-2 reverse split in the gap period halves the unit count but the whole period end holding is
+        // still retained, so the full ERI uplift belongs to the pool.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        StockSplit reverseSplit = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 4, 30),
+            SplitTo = 1,
+            SplitFrom = 2
+        };
+        reverseSplit.ChangeSection104(ukSection104);
+        ukSection104.Quantity.ShouldBe(500m);
+
+        ExcessReportableIncome eri = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            ReportingPeriodEndDate = new DateTime(2023, 12, 31),
+            IncomeType = ExcessReportableIncomeType.DIVIDEND,
+            Amount = new DescribedMoney(500m, "GBP", 1, "ERI")
+        };
+        eri.ChangeSection104(ukSection104);
+
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(10500m));
+    }
+
+    [Fact]
+    public void TestForwardSplitThenDisposalInGapPeriodApportionsInPostSplitUnits()
+    {
+        // A 2-for-1 split in the gap period doubles the unit count, then 800 post split units (= 400 period end
+        // units) are sold. The disposal takes 400 * 0.5 = 200 of the uplift, the pool the remaining 300.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        StockSplit forwardSplit = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 2, 1),
+            SplitTo = 2,
+            SplitFrom = 1
+        };
+        forwardSplit.ChangeSection104(ukSection104);
+        TradeTaxCalculation sellTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2024, 4, 30), 800, 5000m, TradeType.DISPOSAL);
+        sellTrade.MatchWithSection104(ukSection104);
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(4000m)); // 10000 * 800/2000
+
+        ExcessReportableIncome eri = new()
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            ReportingPeriodEndDate = new DateTime(2023, 12, 31),
+            IncomeType = ExcessReportableIncomeType.DIVIDEND,
+            Amount = new DescribedMoney(500m, "GBP", 1, "ERI") // 0.5 per unit for 1000 pre split units
+        };
+        eri.ChangeSection104(ukSection104);
+
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(4200m)); // + 800 post split units * 0.25
+        ukSection104.Quantity.ShouldBe(1200m);
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(6300m)); // 6000 + 1200 * 0.25
+    }
 }

--- a/UnitTest/Test/Model/TaxEvents/FundEqualisationTest.cs
+++ b/UnitTest/Test/Model/TaxEvents/FundEqualisationTest.cs
@@ -1,5 +1,10 @@
+using InvestmentTaxCalculator.Enumerations;
 using InvestmentTaxCalculator.Model;
 using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Model.UkTaxModel;
+using InvestmentTaxCalculator.Model.UkTaxModel.Stocks;
+
+using UnitTest.Helper;
 
 namespace InvestmentTaxCalculator.UnitTest.Test.Model.TaxEvents;
 
@@ -47,5 +52,78 @@ public class FundEqualisationTest
         reason.ShouldContain($"Test Fund fund equalisation of £100.00 on {dateString}");
         reason.ShouldNotContain("()");
         reason.ShouldNotContain(" .");
+    }
+
+    [Fact]
+    public void ChangeSection104_WithoutReportingPeriodEnd_ReducesPoolOnly()
+    {
+        // Legacy behaviour: no reporting period end recorded, the whole amount reduces the pool at the event date.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        TradeTaxCalculation sellTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2024, 4, 30), 400, 5000m, TradeType.DISPOSAL);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        sellTrade.MatchWithSection104(ukSection104);
+
+        var equalisation = new FundEqualisation
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            Amount = new DescribedMoney(100m, "GBP", 1m, "Equalisation")
+        };
+        equalisation.ChangeSection104(ukSection104);
+
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(4000m)); // unchanged
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(5900m)); // 6000 - 100
+    }
+
+    [Fact]
+    public void ChangeSection104_GapPeriodDisposal_TakesShareOfReduction()
+    {
+        // 1000 units held at the reporting period end, 400 sold before the distribution date: the sold units'
+        // share of the equalisation reduces the disposal allowable cost, the rest reduces the pool.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        TradeTaxCalculation sellTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2024, 4, 30), 400, 5000m, TradeType.DISPOSAL);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        sellTrade.MatchWithSection104(ukSection104);
+
+        var equalisation = new FundEqualisation
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            ReportingPeriodEndDate = new DateTime(2023, 12, 31),
+            Amount = new DescribedMoney(100m, "GBP", 1m, "Equalisation") // 0.1 per unit for 1000 units
+        };
+        equalisation.ChangeSection104(ukSection104);
+
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(3960m)); // 4000 - 400 * 0.1
+        sellTrade.Gain.ShouldBe(new WrappedMoney(1040m));
+        ukSection104.Quantity.ShouldBe(600m);
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(new WrappedMoney(5940m)); // 6000 - 600 * 0.1
+    }
+
+    [Fact]
+    public void ChangeSection104_GapPeriodFullDisposal_DoesNotDriveEmptyPoolNegative()
+    {
+        // Selling the whole holding before the distribution date: the reduction lands on the disposal and the
+        // empty pool must not be driven to a negative cost.
+        TradeTaxCalculation buyTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2023, 1, 1), 1000, 10000m, TradeType.ACQUISITION);
+        TradeTaxCalculation sellTrade = MockTrade.CreateTradeTaxCalculation("ETF1", new DateTime(2024, 4, 30), 1000, 14000m, TradeType.DISPOSAL);
+        UkSection104 ukSection104 = new("ETF1");
+        buyTrade.MatchWithSection104(ukSection104);
+        sellTrade.MatchWithSection104(ukSection104);
+
+        var equalisation = new FundEqualisation
+        {
+            AssetName = "ETF1",
+            Date = new DateTime(2024, 6, 30),
+            ReportingPeriodEndDate = new DateTime(2023, 12, 31),
+            Amount = new DescribedMoney(100m, "GBP", 1m, "Equalisation")
+        };
+        equalisation.ChangeSection104(ukSection104);
+
+        sellTrade.TotalAllowableCost.ShouldBe(new WrappedMoney(9900m)); // 10000 - 100
+        ukSection104.Quantity.ShouldBe(0m);
+        ukSection104.AcquisitionCostInBaseCurrency.ShouldBe(WrappedMoney.GetBaseCurrencyZero());
     }
 }

--- a/UnitTest/Test/TradeCalculations/Stocks/UkTradeCalculatorEriGapPeriodTest.cs
+++ b/UnitTest/Test/TradeCalculations/Stocks/UkTradeCalculatorEriGapPeriodTest.cs
@@ -1,0 +1,119 @@
+using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model.Interfaces;
+using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Model.UkTaxModel;
+using InvestmentTaxCalculator.Model.UkTaxModel.Stocks;
+
+using System.Globalization;
+
+using UnitTest.Helper;
+
+namespace UnitTest.Test.TradeCalculations.Stocks;
+
+/// <summary>
+/// Excess reportable income liability is fixed by the holding at the end of the fund reporting period
+/// (SI 2009/3001 reg. 94(3)). Units disposed of in the "gap period" between the period end and the fund
+/// distribution date take their share of the base cost uplift at the disposal (reg. 99(5)), while the
+/// retained units' share is added to the section 104 pool on the fund distribution date (reg. 99(4)).
+/// </summary>
+public class UkTradeCalculatorEriGapPeriodTest
+{
+    private static ExcessReportableIncome CreateEri(decimal totalAmount) => new()
+    {
+        AssetName = "REPORT_FUND",
+        Date = DateTime.Parse("30-Jun-24 00:00:00", CultureInfo.InvariantCulture),
+        ReportingPeriodEndDate = DateTime.Parse("31-Dec-23 00:00:00", CultureInfo.InvariantCulture),
+        IncomeType = ExcessReportableIncomeType.DIVIDEND,
+        Amount = new DescribedMoney(totalAmount, "GBP", 1, "ERI")
+    };
+
+    private static Trade CreateTrade(TradeType tradeType, string date, decimal quantity, decimal amount) => new()
+    {
+        AssetName = "REPORT_FUND",
+        AcquisitionDisposal = tradeType,
+        Date = DateTime.Parse(date, CultureInfo.InvariantCulture),
+        Quantity = quantity,
+        GrossProceed = new() { Amount = new(amount) },
+    };
+
+    [Fact]
+    public void TestGapPeriodSection104DisposalGetsItsShareOfTheUplift()
+    {
+        Trade buy = CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000, 10000m);
+        Trade gapPeriodSell = CreateTrade(TradeType.DISPOSAL, "30-Apr-24 10:00:00", 400, 5000m);
+        ExcessReportableIncome eri = CreateEri(500m); // 0.5 per unit for the 1000 units held at period end
+
+        UkSection104Pools section104Pools = new(new UKTaxYear(), new ResidencyStatusRecord());
+        TaxEventLists taxEventLists = new();
+        taxEventLists.AddData([buy, gapPeriodSell, eri]);
+
+        UkTradeCalculator calculator = TradeCalculationHelper.CreateUkTradeCalculator(section104Pools, taxEventLists);
+        List<ITradeTaxCalculation> result = calculator.CalculateTax();
+
+        ITradeTaxCalculation disposal = result.First(x => x.AcquisitionDisposal == TradeType.DISPOSAL);
+        disposal.MatchHistory.Count.ShouldBe(1);
+        disposal.MatchHistory[0].TradeMatchType.ShouldBe(TaxMatchType.SECTION_104);
+        disposal.TotalAllowableCost.Amount.ShouldBe(4200m, 0.01m); // 4000 + 400 * 0.5 (reg. 99(5))
+        disposal.Gain.Amount.ShouldBe(800m, 0.01m);
+
+        UkSection104 pool = section104Pools.GetExistingOrInitialise("REPORT_FUND");
+        pool.Quantity.ShouldBe(600m);
+        pool.AcquisitionCostInBaseCurrency.Amount.ShouldBe(6300m, 0.01m); // 6000 + 600 * 0.5 (reg. 99(4))
+    }
+
+    [Fact]
+    public void TestBedAndBreakfastGapPeriodDisposalGetsNoUplift()
+    {
+        // The gap period disposal is matched with a repurchase within 30 days (s.106A TCGA 1992), so the units
+        // disposed of are the repurchased ones, not the period end holding. The period end units never leave the
+        // section 104 pool and the full ERI uplift belongs to the pool.
+        Trade buy = CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000, 10000m);
+        Trade gapPeriodSell = CreateTrade(TradeType.DISPOSAL, "30-Apr-24 10:00:00", 400, 5000m);
+        Trade rebuy = CreateTrade(TradeType.ACQUISITION, "10-May-24 10:00:00", 400, 4400m);
+        ExcessReportableIncome eri = CreateEri(500m);
+
+        UkSection104Pools section104Pools = new(new UKTaxYear(), new ResidencyStatusRecord());
+        TaxEventLists taxEventLists = new();
+        taxEventLists.AddData([buy, gapPeriodSell, rebuy, eri]);
+
+        UkTradeCalculator calculator = TradeCalculationHelper.CreateUkTradeCalculator(section104Pools, taxEventLists);
+        List<ITradeTaxCalculation> result = calculator.CalculateTax();
+
+        ITradeTaxCalculation disposal = result.First(x => x.AcquisitionDisposal == TradeType.DISPOSAL);
+        disposal.MatchHistory.Count.ShouldBe(1);
+        disposal.MatchHistory[0].TradeMatchType.ShouldBe(TaxMatchType.BED_AND_BREAKFAST);
+        disposal.TotalAllowableCost.Amount.ShouldBe(4400m, 0.01m); // no ERI uplift on the disposal
+        disposal.Gain.Amount.ShouldBe(600m, 0.01m);
+
+        UkSection104 pool = section104Pools.GetExistingOrInitialise("REPORT_FUND");
+        pool.Quantity.ShouldBe(1000m);
+        pool.AcquisitionCostInBaseCurrency.Amount.ShouldBe(10500m, 0.01m); // full uplift stays with the pool
+    }
+
+    [Fact]
+    public void TestFullDisposalInGapPeriodDoesNotPoisonLaterAcquisition()
+    {
+        // The whole holding is sold in the gap period and a fresh position is opened after the fund distribution
+        // date. The entire uplift belongs to the gap period disposal and must not leak into the new pool.
+        Trade buy = CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000, 10000m);
+        Trade gapPeriodSell = CreateTrade(TradeType.DISPOSAL, "30-Apr-24 10:00:00", 1000, 14500m);
+        Trade laterBuy = CreateTrade(TradeType.ACQUISITION, "01-Aug-24 10:00:00", 100, 1500m);
+        ExcessReportableIncome eri = CreateEri(500m);
+
+        UkSection104Pools section104Pools = new(new UKTaxYear(), new ResidencyStatusRecord());
+        TaxEventLists taxEventLists = new();
+        taxEventLists.AddData([buy, gapPeriodSell, laterBuy, eri]);
+
+        UkTradeCalculator calculator = TradeCalculationHelper.CreateUkTradeCalculator(section104Pools, taxEventLists);
+        List<ITradeTaxCalculation> result = calculator.CalculateTax();
+
+        ITradeTaxCalculation disposal = result.First(x => x.AcquisitionDisposal == TradeType.DISPOSAL);
+        disposal.TotalAllowableCost.Amount.ShouldBe(10500m, 0.01m); // 10000 + full 500 uplift (reg. 99(5))
+        disposal.Gain.Amount.ShouldBe(4000m, 0.01m);
+
+        UkSection104 pool = section104Pools.GetExistingOrInitialise("REPORT_FUND");
+        pool.Quantity.ShouldBe(100m);
+        pool.AcquisitionCostInBaseCurrency.Amount.ShouldBe(1500m, 0.01m); // unaffected by the ERI
+    }
+}


### PR DESCRIPTION
## Summary
Implements proper handling of excess reportable income (ERI) and fund equalisation adjustments for disposals made in the "gap period" between the fund reporting period end and the fund distribution date, in accordance with SI 2009/3001 regulations 94 and 99.

## Key Changes

- **New `ReportingFundCostAllocator` class**: Splits cost adjustments (ERI uplifts or equalisation reductions) between gap period disposals and the section 104 pool based on units held at the reporting period end. Units disposed of before the distribution date take their share at the disposal (reg. 99(5)), while retained units' share is applied to the pool (reg. 99(4)).

- **Enhanced `ExcessReportableIncome`**: 
  - Added `ReportingPeriodEndDate` property to track the fund reporting period end
  - Added `EffectiveReportingPeriodEndDate` that defaults to 6 months before distribution date for legacy files (reg. 94(4))
  - Updated `ChangeSection104()` to use `ReportingFundCostAllocator` for proper apportionment

- **Enhanced `FundEqualisation`**:
  - Added `ReportingPeriodEndDate` property to enable gap period cost allocation
  - Updated `ChangeSection104()` to use `ReportingFundCostAllocator` when period end is specified
  - Maintains backward compatibility by reducing pool directly when period end is null

- **UI Updates**:
  - `EriControl.razor`: Now captures and stores the reporting period end date when creating ERI events
  - `EqualisationControl.razor`: Automatically populates reporting period end from related ERI events or defaults to 6 months before distribution

- **Comprehensive Test Coverage**:
  - Added 5 new unit tests in `ExcessReportableIncomeTest` covering partial disposals, full disposals, legacy files, pro-rata apportionment, and pre-period-end disposals
  - Added 3 new integration tests in `UkTradeCalculatorEriGapPeriodTest` covering section 104 disposals, bed-and-breakfast matching, and full disposals
  - Added 3 new tests in `FundEqualisationTest` covering gap period cost reduction scenarios

## Implementation Details

The allocator uses a "just and reasonable" apportionment approach: when a fungible pool disposal occurs, the proportion of period-end units disposed is calculated as `(period-end units remaining) × (disposal quantity) / (pool quantity before disposal)`. This ensures proper handling of multiple gap period disposals and acquisitions between the period end and distribution date.

The solution maintains backward compatibility with older saved files that lack reporting period end dates by defaulting to the regulatory assumption of 6 months prior to the distribution date.

https://claude.ai/code/session_01P7r2j7v7dAu3UpRkZK7ncK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of UK excess reportable income and equalisation so reporting-period end dates are now tracked and used in calculations.
  * Added more accurate allocation of tax cost adjustments across disposals and remaining holdings during the reporting “gap period.”

* **Bug Fixes**
  * Fixed cases where gap-period disposals could receive incorrect cost-base treatment.
  * Prevented empty holdings from being driven negative and improved fallback behavior when no reporting-period date is available.

* **Documentation**
  * Expanded project guidance to describe the updated ERI and equalisation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->