### PR TITLE
Fix Playwright browser install path in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
      - name: Run unit tests
        run: dotnet test UnitTest/UnitTest.csproj --collect:"XPlat Code Coverage"
      - name: Install Playwright browsers
-       run: pwsh PlaywrightTests/bin/Release/net10.0-windows10.0.22621.0/playwright.ps1 install --with-deps
+       run: pwsh PlaywrightTests/bin/Release/net10.0/playwright.ps1 install --with-deps
      - name: Run Playwright tests
        run: dotnet test PlaywrightTests/PlaywrightTests.csproj --configuration Release
      - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## Summary

PR #244 switched `PlaywrightTests` from the Windows-specific target framework (`net10.0-windows10.0.22621.0`) to plain `net10.0`, which moved the Release build output to `PlaywrightTests/bin/Release/net10.0/`. The CI workflow's "Install Playwright browsers" step still pointed at the old path, so the build failed with:

```
'PlaywrightTests/bin/Release/net10.0-windows10.0.22621.0/playwright.ps1' is not recognized as the name of a script file.
```

This updates the hardcoded path to `PlaywrightTests/bin/Release/net10.0/playwright.ps1`.

## Test plan

- [x] Built `PlaywrightTests` locally in Release configuration and confirmed `playwright.ps1` is produced at `PlaywrightTests/bin/Release/net10.0/playwright.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7r2j7v7dAu3UpRkZK7ncK

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7r2j7v7dAu3UpRkZK7ncK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated browser setup step in the build pipeline to use the current build output location, helping keep test runs working smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->