### PR TITLE
Initialize SelectedSections with all available sections by default

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Services/PdfExport/PdfExportService.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/PdfExport/PdfExportService.cs
@@ -12,7 +12,7 @@ namespace InvestmentTaxCalculator.Services.PdfExport;
 public class PdfExportService
 {
     public List<ISection> AllSections { get; set; }
-    public string[]? SelectedSections { get; set; } = [];
+    public string[]? SelectedSections { get; set; }
     public PdfExportService(TaxYearReportService taxYearReportService, TradeCalculationResult tradeCalculationResult,
         UkSection104Pools uKSection104Pools, DividendCalculationResult dividendCalculationResult)
     {
@@ -32,6 +32,7 @@ public class PdfExportService
             section104Section,
             allTradesListSection
             ];
+        SelectedSections = [.. AllSections.Select(section => section.Name)];
     }
     public MemoryStream CreatePdf(int year)
     {


### PR DESCRIPTION
## Summary
Updated the `PdfExportService` to automatically populate `SelectedSections` with all available section names during initialization, rather than starting with an empty array.

## Key Changes
- Removed the empty array initializer (`[]`) from the `SelectedSections` property declaration
- Added initialization logic in the constructor to populate `SelectedSections` with all section names from `AllSections` using a collection expression

## Implementation Details
The `SelectedSections` property is now initialized after `AllSections` is fully populated, ensuring all sections are selected by default when a PDF export service instance is created. This provides a better user experience by having all available sections pre-selected rather than requiring users to manually select them.

https://claude.ai/code/session_018MKGnWZhzxDBWrmEJynGWv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PDF exports now include all available sections by default.
  * Export selection is automatically populated when the PDF export service starts, while still allowing sections to be changed before exporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->