### PR TITLE
Export residency status settings with tax events

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Components/ExportFile.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ExportFile.razor
@@ -33,8 +33,8 @@
         <div class="alert alert-info alert-custom mb-4" role="alert">
             <h5 class="alert-heading">About Data Export</h5>
             <p class="mb-2">
-                The <strong>Export data for future import</strong> button generates a .json file containing all your imported data, 
-                manually added trades, ERI/equalisation payments, and other manual corporate action adjustments.
+                The <strong>Export data for future import</strong> button generates a .json file containing all your imported data,
+                manually added trades, ERI/equalisation payments, other manual corporate action adjustments and your residency status setting.
             </p>
             <p class="mb-0">
                 Importing this file instead of broker statements in the future will be much faster and preserve all your manual adjustments.

--- a/BlazorApp-Investment Tax Calculator/Model/ExportImportData.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/ExportImportData.cs
@@ -1,0 +1,14 @@
+namespace InvestmentTaxCalculator.Model;
+
+/// <summary>
+/// Serialisation shape of the "Export data for future import" file. Extends the tax event lists with
+/// user settings so the JSON stays a superset of the old format: files without the extra properties
+/// still import, and old app versions ignore the properties they don't know.
+/// </summary>
+public record ExportImportData : TaxEventLists
+{
+    /// <summary>
+    /// Residency status setting. Null when importing a file saved before this property existed.
+    /// </summary>
+    public List<ResidencyStatusRecord.RangeEntry>? ResidencyStatusRanges { get; set; }
+}

--- a/BlazorApp-Investment Tax Calculator/Model/TaxEventLists.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TaxEventLists.cs
@@ -1,6 +1,8 @@
 ﻿using InvestmentTaxCalculator.Model.Interfaces;
 using InvestmentTaxCalculator.Model.TaxEvents;
 
+using System.Text.Json.Serialization;
+
 namespace InvestmentTaxCalculator.Model;
 
 public record TaxEventLists : IDividendLists, ITradeAndCorporateActionList
@@ -12,6 +14,7 @@ public record TaxEventLists : IDividendLists, ITradeAndCorporateActionList
     public List<FutureContractTrade> FutureContractTrades { get; set; } = [];
     public List<CashSettlement> CashSettlements { get; set; } = [];
     public List<InterestIncome> InterestIncomes { get; set; } = [];
+    [JsonIgnore]
     public IEnumerable<TaxEvent> AllEvents => Trades.Cast<TaxEvent>()
         .Concat(CorporateActions.Cast<TaxEvent>())
         .Concat(Dividends.Cast<TaxEvent>())

--- a/BlazorApp-Investment Tax Calculator/Parser/Json/JsonParseController.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/Json/JsonParseController.cs
@@ -1,4 +1,4 @@
-﻿using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model;
 using InvestmentTaxCalculator.Model.TaxEvents;
 
 using System.Text.Json;
@@ -6,14 +6,17 @@ using System.Text.Json.Serialization;
 
 namespace InvestmentTaxCalculator.Parser.Json;
 
-public class JsonParseController(AssetTypeToLoadSetting assetTypeToLoadSetting) : ITaxEventFileParser
+public class JsonParseController(AssetTypeToLoadSetting assetTypeToLoadSetting, ResidencyStatusRecord residencyStatusRecord) : ITaxEventFileParser
 {
     public TaxEventLists ParseFile(string data)
     {
-        TaxEventLists? result = null;
-        result = JsonSerializer.Deserialize(data, MyJsonContext.Default.TaxEventLists);
         TaxEventLists resultFiltered = new();
+        ExportImportData? result = JsonSerializer.Deserialize(data, MyJsonContext.Default.ExportImportData);
         if (result == null) return resultFiltered;
+        if (result.ResidencyStatusRanges is { Count: > 0 })
+        {
+            residencyStatusRecord.Ranges = result.ResidencyStatusRanges;
+        }
         resultFiltered = assetTypeToLoadSetting.FilterTaxEvent(result);
         return resultFiltered;
     }
@@ -29,6 +32,7 @@ public class JsonParseController(AssetTypeToLoadSetting assetTypeToLoadSetting) 
 /// Workaround due to trimmer problem https://github.com/dotnet/runtime/issues/62242
 /// </summary>
 [JsonSerializable(typeof(TaxEventLists))]
+[JsonSerializable(typeof(ExportImportData))]
 [JsonSerializable(typeof(ExcessReportableIncome))]
 [JsonSerializable(typeof(FundEqualisation))]
 internal partial class MyJsonContext : JsonSerializerContext { }

--- a/BlazorApp-Investment Tax Calculator/Services/ExportTaxEventService.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/ExportTaxEventService.cs
@@ -1,14 +1,25 @@
-﻿using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model;
 
 using System.Text.Json;
 
 namespace InvestmentTaxCalculator.Services;
 
-public class ExportTaxEventService(TaxEventLists taxEventLists)
+public class ExportTaxEventService(TaxEventLists taxEventLists, ResidencyStatusRecord residencyStatusRecord)
 {
     private readonly JsonSerializerOptions _options = new() { WriteIndented = true };
     public string SerialiseTaxEvents()
     {
-        return JsonSerializer.Serialize(taxEventLists, _options);
+        ExportImportData exportData = new()
+        {
+            Trades = taxEventLists.Trades,
+            CorporateActions = taxEventLists.CorporateActions,
+            Dividends = taxEventLists.Dividends,
+            OptionTrades = taxEventLists.OptionTrades,
+            FutureContractTrades = taxEventLists.FutureContractTrades,
+            CashSettlements = taxEventLists.CashSettlements,
+            InterestIncomes = taxEventLists.InterestIncomes,
+            ResidencyStatusRanges = residencyStatusRecord.Ranges
+        };
+        return JsonSerializer.Serialize(exportData, _options);
     }
 }

--- a/UnitTest/Test/Services/ExportTaxEventServiceTest.cs
+++ b/UnitTest/Test/Services/ExportTaxEventServiceTest.cs
@@ -31,6 +31,7 @@ public class ExportTaxEventServiceTest
         ExportTaxEventService exportService = new(taxEventLists, exportResidencyRecord);
 
         string json = exportService.SerialiseTaxEvents();
+        json.ShouldNotContain("\"AllEvents\"");
 
         ResidencyStatusRecord importResidencyRecord = new();
         JsonParseController importController = new(new AssetTypeToLoadSetting(), importResidencyRecord);

--- a/UnitTest/Test/Services/ExportTaxEventServiceTest.cs
+++ b/UnitTest/Test/Services/ExportTaxEventServiceTest.cs
@@ -1,0 +1,63 @@
+using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Parser.Json;
+using InvestmentTaxCalculator.Services;
+
+using System.Text.Json;
+
+using ResidencyEnum = InvestmentTaxCalculator.Enumerations.ResidencyStatus;
+
+namespace UnitTest.Test.Services;
+
+public class ExportTaxEventServiceTest
+{
+    private static Trade CreateTrade() => new()
+    {
+        AssetName = "ABC",
+        Date = new DateTime(2024, 5, 1),
+        AcquisitionDisposal = TradeType.ACQUISITION,
+        Quantity = 100,
+        GrossProceed = new DescribedMoney(1000m, "GBP", 1m)
+    };
+
+    [Fact]
+    public void ExportedFile_RoundTripsTaxEventsAndResidencyStatus()
+    {
+        TaxEventLists taxEventLists = new();
+        taxEventLists.Trades.Add(CreateTrade());
+        ResidencyStatusRecord exportResidencyRecord = new();
+        exportResidencyRecord.SetResidencyStatus(new DateOnly(2020, 4, 6), new DateOnly(2023, 4, 5), ResidencyEnum.NonResident);
+        ExportTaxEventService exportService = new(taxEventLists, exportResidencyRecord);
+
+        string json = exportService.SerialiseTaxEvents();
+
+        ResidencyStatusRecord importResidencyRecord = new();
+        JsonParseController importController = new(new AssetTypeToLoadSetting(), importResidencyRecord);
+        TaxEventLists imported = importController.ParseFile(json);
+
+        imported.Trades.Count.ShouldBe(1);
+        imported.Trades[0].AssetName.ShouldBe("ABC");
+        importResidencyRecord.Ranges.ShouldBe(exportResidencyRecord.Ranges);
+        importResidencyRecord.GetResidencyStatus(new DateOnly(2021, 1, 1)).ShouldBe(ResidencyEnum.NonResident);
+        importResidencyRecord.GetResidencyStatus(new DateOnly(2024, 1, 1)).ShouldBe(ResidencyEnum.Resident);
+    }
+
+    [Fact]
+    public void ImportingOldFormatFile_WithoutResidencyStatus_LeavesResidencyRecordUntouched()
+    {
+        TaxEventLists taxEventLists = new();
+        taxEventLists.Trades.Add(CreateTrade());
+        string oldFormatJson = JsonSerializer.Serialize(taxEventLists);
+
+        ResidencyStatusRecord importResidencyRecord = new();
+        importResidencyRecord.SetResidencyStatus(new DateOnly(2020, 4, 6), new DateOnly(2023, 4, 5), ResidencyEnum.NonResident);
+        List<ResidencyStatusRecord.RangeEntry> rangesBeforeImport = [.. importResidencyRecord.Ranges];
+        JsonParseController importController = new(new AssetTypeToLoadSetting(), importResidencyRecord);
+
+        TaxEventLists imported = importController.ParseFile(oldFormatJson);
+
+        imported.Trades.Count.ShouldBe(1);
+        importResidencyRecord.Ranges.ShouldBe(rangesBeforeImport);
+    }
+}


### PR DESCRIPTION
## Summary
This PR extends the export/import functionality to include residency status settings alongside tax events. The exported JSON file now contains user's residency status configuration, enabling complete data preservation when exporting for future import.

## Key Changes
- **New `ExportImportData` model**: Created a serialization wrapper that extends `TaxEventLists` with an optional `ResidencyStatusRanges` property, maintaining backward compatibility with old file formats
- **Updated `ExportTaxEventService`**: Now accepts `ResidencyStatusRecord` as a dependency and includes residency status ranges in the exported JSON
- **Enhanced `JsonParseController`**: Modified to deserialize into `ExportImportData` and restore residency status settings from imported files when present
- **Backward compatibility**: Old format files (without residency status) continue to import successfully without affecting existing residency settings
- **Updated UI documentation**: Modified the export file component to reflect that residency status is now included in exports

## Implementation Details
- The `ExportImportData` record uses nullable `ResidencyStatusRanges` to support both old and new file formats
- Import logic checks if residency ranges exist before updating the record, preserving user settings when importing legacy files
- Added `ExportImportData` to the JSON serialization context for proper trimmer support in Blazor
- Comprehensive unit tests verify round-trip serialization and backward compatibility scenarios

https://claude.ai/code/session_01FVqBE9Uzwz91vK4V8XfkfR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exported JSON files now include residency status settings alongside imported data, manually added trades, ERI/equalisation payments, and other manual corporate action adjustments.
  * Importing an exported file restores the included residency status settings.
* **Bug Fixes**
  * Older export files that don’t contain residency status data remain supported, leaving existing residency settings unchanged.
* **Documentation**
  * Updated the “About Data Export” description to accurately list everything included in the generated JSON.
* **Tests**
  * Added coverage for JSON round-tripping and backward compatibility for legacy exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->