### PR TITLE
Add FUND asset class for ETFs and mutual funds

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Components/AssetNameSelector.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/AssetNameSelector.razor
@@ -63,6 +63,14 @@ else
                 }
             }
 
+            if (categoryFilter.Contains(AssetCategoryType.FUND))
+            {
+                foreach (string assetName in TaxEventLists.Trades.Where(t => t.AssetType == AssetCategoryType.FUND).Select(t => t.AssetName))
+                {
+                    allowedAssetNames.Add(assetName);
+                }
+            }
+
             if (categoryFilter.Contains(AssetCategoryType.OPTION))
             {
                 foreach (string assetName in TaxEventLists.OptionTrades.Select(t => t.AssetName))

--- a/BlazorApp-Investment Tax Calculator/Components/AssetTypeToLoad.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/AssetTypeToLoad.razor
@@ -7,6 +7,10 @@
         <RadzenLabel Text="Load Stocks" Component="loadStocks" class="ms-2" />
     </div>
     <div class="col-md-6 col-lg-4">
+        <RadzenCheckBox @bind-Value="@AssetSettings.LoadFunds" Name="loadFunds" />
+        <RadzenLabel Text="Load Funds (ETF/Mutual Funds)" Component="loadFunds" class="ms-2" />
+    </div>
+    <div class="col-md-6 col-lg-4">
         <RadzenCheckBox @bind-Value="@AssetSettings.LoadOptions" Name="loadOptions" />
         <RadzenLabel Text="Load Options" Component="loadOptions" class="ms-2" />
     </div>

--- a/BlazorApp-Investment Tax Calculator/Components/CorporateActionHeader.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/CorporateActionHeader.razor
@@ -92,7 +92,7 @@
     [Parameter] public bool IsDestinationDisabled { get; set; }
     [Parameter] public bool AllowManualSourceAssetNameInput { get; set; }
     [Parameter] public bool AllowManualDestinationAssetNameInput { get; set; } = true;
-    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK];
+    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK, AssetCategoryType.FUND];
     [Parameter] public int RatioDecimals { get; set; } = 4;
     [Parameter] public string RatioFormat { get; set; } = "n4";
     [Parameter] public decimal RatioMin { get; set; } = 0.0001m;

--- a/BlazorApp-Investment Tax Calculator/Components/EqualisationControl.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/EqualisationControl.razor
@@ -70,7 +70,7 @@
     [Parameter] public bool IsCalculationMissing { get; set; }
     [Parameter] public EventCallback OnDataChanged { get; set; }
     [Parameter] public bool AllowManualAssetNameInput { get; set; }
-    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK];
+    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK, AssetCategoryType.FUND];
 
     private List<string> AvailableTickers { get; set; } = new();
     private string SelectedTicker { get; set; } = string.Empty;
@@ -95,7 +95,7 @@
             .ToHashSet();
 
         AvailableTickers = Section104Pools.GetSection104s()
-            .Where(p => TaxEventLists.Trades.Any(t => t.AssetName == p.AssetName && t.AssetType == AssetCategoryType.STOCK))
+            .Where(p => TaxEventLists.Trades.Any(t => t.AssetName == p.AssetName && t.AssetType is AssetCategoryType.STOCK or AssetCategoryType.FUND))
             .Select(p => p.AssetName)
             .Where(name => tickersWithIncome.Contains(name))
             .Distinct()

--- a/BlazorApp-Investment Tax Calculator/Components/EriControl.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/EriControl.razor
@@ -87,7 +87,7 @@
     [Parameter] public bool IsCalculationMissing { get; set; }
     [Parameter] public EventCallback OnDataChanged { get; set; }
     [Parameter] public bool AllowManualAssetNameInput { get; set; }
-    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK];
+    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK, AssetCategoryType.FUND];
 
     private DateTime? PeriodEndDate { get; set; }
     private string SelectedTicker { get; set; } = string.Empty;

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/DividendManualEntryForm.razor
@@ -80,7 +80,7 @@
     private List<CurrencyViewModel> _currencies = [];
     private List<EnumDescriptionPair<DividendType>> _dividendTypes = [];
     private List<CountryCodeOption> _countryCodes = [];
-    private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.STOCK];
+    private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.STOCK, AssetCategoryType.FUND];
     private int? _loadedEditingTaxEventId;
     private bool IsEditing => EditingTaxEventId.HasValue;
 

--- a/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ManualEntries/InterestIncomeManualEntryForm.razor
@@ -94,7 +94,7 @@
     private List<CurrencyViewModel> _currencies = [];
     private List<EnumDescriptionPair<InterestType>> _interestTypes = [];
     private List<CountryCodeOption> _countryCodes = [];
-    private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.STOCK];
+    private static readonly List<AssetCategoryType> _assetCategoryFilter = [AssetCategoryType.STOCK, AssetCategoryType.FUND];
     private int? _loadedEditingTaxEventId;
     private bool IsEditing => EditingTaxEventId.HasValue;
 

--- a/BlazorApp-Investment Tax Calculator/Components/PartnerTransfer.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/PartnerTransfer.razor
@@ -87,7 +87,7 @@
     [Parameter] public EventCallback OnCorporateActionAdded { get; set; }
     [Parameter] public PartnerTransferCorporateAction? ActionToEdit { get; set; }
     [Parameter] public bool AllowManualAssetNameInput { get; set; } = true;
-    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK];
+    [Parameter] public List<AssetCategoryType> AssetCategoryFilter { get; set; } = [AssetCategoryType.STOCK, AssetCategoryType.FUND];
 
     private DateTime _date = DateTime.Today;
     private string? _ticker;

--- a/BlazorApp-Investment Tax Calculator/Enumerations/AssetCatagoryType.cs
+++ b/BlazorApp-Investment Tax Calculator/Enumerations/AssetCatagoryType.cs
@@ -15,7 +15,10 @@ public enum AssetCategoryType
     FX,
     [HmrcAssetCategoryType(AssetGroupType.OTHERASSETS)]
     [Description("Option")]
-    OPTION
+    OPTION,
+    [HmrcAssetCategoryType(AssetGroupType.LISTEDSHARES)]
+    [Description("Fund/ETF")]
+    FUND
 }
 
 public enum AssetGroupType

--- a/BlazorApp-Investment Tax Calculator/Model/AssetTypeToLoadSetting.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/AssetTypeToLoadSetting.cs
@@ -5,6 +5,7 @@ namespace InvestmentTaxCalculator.Model;
 public class AssetTypeToLoadSetting
 {
     public bool LoadStocks { get; set; } = true;
+    public bool LoadFunds { get; set; } = true;
     public bool LoadOptions { get; set; } = true;
     public bool LoadFutures { get; set; } = true;
     public bool LoadFx { get; set; } = true;
@@ -17,6 +18,7 @@ public class AssetTypeToLoadSetting
         if (LoadDividends) resultFiltered.Dividends.AddRange(taxEventLists.Dividends);
         resultFiltered.CorporateActions.AddRange(taxEventLists.CorporateActions);
         if (LoadStocks) resultFiltered.Trades.AddRange(taxEventLists.Trades.Where(trade => trade.AssetType == AssetCategoryType.STOCK));
+        if (LoadFunds) resultFiltered.Trades.AddRange(taxEventLists.Trades.Where(trade => trade.AssetType == AssetCategoryType.FUND));
         if (LoadFutures) resultFiltered.FutureContractTrades.AddRange(taxEventLists.FutureContractTrades);
         if (LoadFx) resultFiltered.Trades.AddRange(taxEventLists.Trades.Where(trade => trade.AssetType == AssetCategoryType.FX));
         if (LoadOptions) resultFiltered.OptionTrades.AddRange(taxEventLists.OptionTrades);

--- a/BlazorApp-Investment Tax Calculator/Model/TradeTaxCalculationFactory.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/TradeTaxCalculationFactory.cs
@@ -36,8 +36,8 @@ public class TradeTaxCalculationFactory(ResidencyStatusRecord residencyStatusRec
     public List<TradeTaxCalculation> GroupTrade(IEnumerable<Trade> trades)
     {
         var groupedTrade = from trade in trades
-                           where trade.AssetType == AssetCategoryType.STOCK
-                           group trade by new { trade.AssetName, trade.Date.Date, trade.AcquisitionDisposal };
+                           where trade.AssetType is AssetCategoryType.STOCK or AssetCategoryType.FUND
+                           group trade by new { trade.AssetName, trade.Date.Date, trade.AcquisitionDisposal, trade.AssetType };
         var groupedFxTrade = from trade in trades
                              where trade.AssetType == AssetCategoryType.FX
                              group trade by new { trade.AssetName, trade.Date.Date, trade.AcquisitionDisposal };

--- a/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/Stocks/UkTradeCalculator.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/Stocks/UkTradeCalculator.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace InvestmentTaxCalculator.Model.UkTaxModel.Stocks;
 
 /// <summary>
-/// Calculate Fx and stock trades
+/// Calculate Fx, stock and fund (ETF/mutual fund) trades
 /// </summary>
 /// <param name="section104Pools"></param>
 /// <param name="tradeList"></param>

--- a/BlazorApp-Investment Tax Calculator/Pages/AddExcessReportableIncome.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/AddExcessReportableIncome.razor
@@ -140,7 +140,7 @@
     private bool _isCalculationMissing = false;
     private bool _dataChanged = false;
     private IDisposable? _registration;
-    private static readonly List<AssetCategoryType> _stockAssetCategoryFilter = [AssetCategoryType.STOCK];
+    private static readonly List<AssetCategoryType> _stockAssetCategoryFilter = [AssetCategoryType.STOCK, AssetCategoryType.FUND];
 
     protected override void OnInitialized()
     {

--- a/BlazorApp-Investment Tax Calculator/Pages/TakeoverCorporateActionPage.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/TakeoverCorporateActionPage.razor
@@ -75,7 +75,7 @@
     private CorporateActionsList? _historyList;
     private bool _hasChanges = false;
     private IDisposable? _navigationRegistration;
-    private static readonly List<AssetCategoryType> _stockAssetCategoryFilter = [AssetCategoryType.STOCK];
+    private static readonly List<AssetCategoryType> _stockAssetCategoryFilter = [AssetCategoryType.STOCK, AssetCategoryType.FUND];
     
     private List<string> _actionTypes = new() { "Takeover / Merger", "Spinoff", "Stock Split / Reverse Split", "Gift to partner", "Receive from partner" };
     private string? _selectedAction = "Takeover / Merger";

--- a/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBParseController.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBParseController.cs
@@ -18,6 +18,7 @@ public class IBParseController(AssetTypeToLoadSetting assetTypeToLoadSetting) : 
             if (assetTypeToLoadSetting.LoadDividends) result.CorporateActions.AddRange(IBXmlDividendParser.ParseReturnOfCapital(xml));
             result.CorporateActions.AddRange(IBXmlStockSplitParser.ParseXml(xml));
             if (assetTypeToLoadSetting.LoadStocks) result.Trades.AddRange(IBXmlStockTradeParser.ParseXml(xml));
+            if (assetTypeToLoadSetting.LoadFunds) result.Trades.AddRange(IBXmlStockTradeParser.ParseFundXml(xml));
             if (assetTypeToLoadSetting.LoadFutures) result.FutureContractTrades.AddRange(IBXmlFutureTradeParser.ParseXml(xml));
             if (assetTypeToLoadSetting.LoadFx) result.Trades.AddRange(_xmlFxParser.ParseXml(xml));
             if (assetTypeToLoadSetting.LoadOptions) result.OptionTrades.AddRange(IBXmlOptionTradeParser.ParseXml(xml));

--- a/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlStockTradeParser.cs
+++ b/BlazorApp-Investment Tax Calculator/Parser/InteractiveBrokersXml/IBXmlStockTradeParser.cs
@@ -9,15 +9,30 @@ public static class IBXmlStockTradeParser
 {
     public static IList<Trade> ParseXml(XElement document)
     {
-        IEnumerable<XElement> filteredElements = document.Descendants("Order").Where(row => row.GetAttribute("levelOfDetail") == "ORDER" &&
-                                                 row.GetAttribute("assetCategory") == "STK");
-        return filteredElements.Select(element => XmlParserHelper.ParserExceptionManager(TradeMaker, element)).Where(trade => trade != null).ToList()!;
+        return ParseXml(document, "STK", AssetCategoryType.STOCK);
     }
 
-    private static Trade? TradeMaker(XElement element)
+    /// <summary>
+    /// IBKR reports mutual funds and some ETFs with assetCategory="FUND".
+    /// They are parsed like stock trades but tagged as FUND asset category.
+    /// </summary>
+    public static IList<Trade> ParseFundXml(XElement document)
+    {
+        return ParseXml(document, "FUND", AssetCategoryType.FUND);
+    }
+
+    private static IList<Trade> ParseXml(XElement document, string ibAssetCategory, AssetCategoryType assetCategoryType)
+    {
+        IEnumerable<XElement> filteredElements = document.Descendants("Order").Where(row => row.GetAttribute("levelOfDetail") == "ORDER" &&
+                                                 row.GetAttribute("assetCategory") == ibAssetCategory);
+        return filteredElements.Select(element => XmlParserHelper.ParserExceptionManager(e => TradeMaker(e, assetCategoryType), element)).Where(trade => trade != null).ToList()!;
+    }
+
+    private static Trade? TradeMaker(XElement element, AssetCategoryType assetCategoryType)
     {
         return new Trade
         {
+            AssetType = assetCategoryType,
             AcquisitionDisposal = element.GetTradeType(),
             AssetName = element.GetAttribute("symbol"),
             Description = element.GetAttribute("description"),

--- a/BlazorApp-Investment Tax Calculator/ViewModel/TradeInputViewModel.cs
+++ b/BlazorApp-Investment Tax Calculator/ViewModel/TradeInputViewModel.cs
@@ -61,7 +61,7 @@ public class TradeInputViewModel
         if (CommissionAmount != 0) expenses.Add(new(CommissionAmount, CommissionCurrency, CommissionExchangeRate));
         return AssetType switch
         {
-            AssetCategoryType.STOCK => new Trade()
+            AssetCategoryType.STOCK or AssetCategoryType.FUND => new Trade()
             {
                 AssetName = AssetName,
                 Date = Date,

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ https://github.com/alexpung/UK-Investment-tax-calculator/tree/master/BlazorApp-I
 ### Parsed trade type:
 1. Trades:
     1. Stock orders
-    2. Future contracts (closed, not settled)
-    3. Capital gain from foreign currency
+    2. Fund orders (ETFs/mutual funds reported by IBKR with asset category "FUND", treated as listed securities)
+    3. Future contracts (closed, not settled)
+    4. Capital gain from foreign currency
 2. Dividend income
     1. Dividend cash income
     2. Witholding tax paid
@@ -123,7 +124,7 @@ Add each of the sections listed below. Clicking a section opens a pop-up listing
 
 #### Trades — Level of detail: **Orders**
 
-Used for stock, future and option trades.
+Used for stock, fund (ETF/mutual fund), future and option trades.
 
 Required fields: `levelOfDetail`, `assetCategory` (Asset Class), `buySell` (Buy/Sell), `symbol`, `isin`, `description`, `dateTime` (Date/Time), `quantity`, `proceeds`, `taxes`, `ibCommission` (IB Commission), `ibCommissionCurrency` (IB Commission Currency), `currency`, `fxRateToBase` (FX Rate to Base), `notes` (Notes/Codes).
 

--- a/UnitTest/Test/Model/TradeCalculationResultTest.cs
+++ b/UnitTest/Test/Model/TradeCalculationResultTest.cs
@@ -177,5 +177,21 @@ public class TradeCalculationResultTests
         (result.GetDisposalProceeds(taxYearsFilter, AssetGroupType.LISTEDSHARES) + result.GetDisposalProceeds(taxYearsFilter, AssetGroupType.OTHERASSETS)).ShouldBe(expectedTotalProceeds);
     }
 
+    [Fact]
+    public void FundDisposal_CountsAsListedShares()
+    {
+        AssetCategoryType.FUND.GetHmrcAssetCategoryType().ShouldBe(AssetGroupType.LISTEDSHARES);
+
+        var mock = SetUpMockTradeTaxCalculation(new DateTime(2021, 5, 1), TradeType.DISPOSAL, 100, 300, AssetCategoryType.FUND, gain: 200);
+        var taxYear = new MockTaxYear();
+        var result = new TradeCalculationResult(taxYear, _residencyStatusRecord);
+        result.SetResult([mock]);
+        var taxYearsFilter = new List<int> { 2021 };
+
+        result.GetNumberOfDisposals(taxYearsFilter, AssetGroupType.LISTEDSHARES).ShouldBe(1);
+        result.GetTotalGain(taxYearsFilter, AssetGroupType.LISTEDSHARES).ShouldBe(new WrappedMoney(200));
+        result.GetNumberOfDisposals(taxYearsFilter, AssetGroupType.OTHERASSETS).ShouldBe(0);
+    }
+
 
 }

--- a/UnitTest/Test/Parser/IBXmlParseControllerTest.cs
+++ b/UnitTest/Test/Parser/IBXmlParseControllerTest.cs
@@ -1,4 +1,5 @@
-﻿using InvestmentTaxCalculator.Model;
+﻿using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model;
 using InvestmentTaxCalculator.Parser.InteractiveBrokersXml;
 
 namespace UnitTest.Test.Parser;
@@ -37,6 +38,33 @@ public class IBXmlParseControllerTest
         IBParseController iBParseController = new(assetTypeToLoadSetting);
         TaxEventLists results = iBParseController.ParseFile(_taxExampleXml);
 
+    }
+
+    [Fact]
+    public void TestFundTradesLoadedWhenLoadFundsEnabled()
+    {
+        AssetTypeToLoadSetting assetTypeToLoadSetting = new()
+        {
+            LoadStocks = false,
+            LoadOptions = false,
+            LoadFutures = false,
+            LoadFx = false,
+            LoadDividends = false,
+            LoadInterestIncome = false
+        };
+        IBParseController iBParseController = new(assetTypeToLoadSetting);
+        TaxEventLists results = iBParseController.ParseFile(_taxExampleXml);
+        results.Trades.Count.ShouldBe(2);
+        results.Trades.ShouldAllBe(trade => trade.AssetType == AssetCategoryType.FUND);
+    }
+
+    [Fact]
+    public void TestFundTradesNotLoadedWhenLoadFundsDisabled()
+    {
+        AssetTypeToLoadSetting assetTypeToLoadSetting = new() { LoadFunds = false };
+        IBParseController iBParseController = new(assetTypeToLoadSetting);
+        TaxEventLists results = iBParseController.ParseFile(_taxExampleXml);
+        results.Trades.ShouldAllBe(trade => trade.AssetType != AssetCategoryType.FUND);
     }
 }
 

--- a/UnitTest/Test/Parser/IBXmlParseTest.cs
+++ b/UnitTest/Test/Parser/IBXmlParseTest.cs
@@ -37,6 +37,19 @@ public class IBXmlParseTest
         parsedData.Count(trade => trade.AcquisitionDisposal == TradeType.DISPOSAL).ShouldBe(3);
         parsedData.First(t => t.AssetName == "ABC").Isin.ShouldBe("US9999999999");
         parsedData.First(t => t.AssetName == "DEF").Isin.ShouldBe("GB0000000000");
+        parsedData.ShouldAllBe(trade => trade.AssetType == AssetCategoryType.STOCK);
+    }
+
+    [Fact]
+    public void TestReadingIBXmlFundTrades()
+    {
+        IList<Trade> parsedData = IBXmlStockTradeParser.ParseFundXml(_xmlDoc);
+        parsedData.Count.ShouldBe(2);
+        parsedData.ShouldAllBe(trade => trade.AssetType == AssetCategoryType.FUND);
+        parsedData.Count(trade => trade.AcquisitionDisposal == TradeType.ACQUISITION).ShouldBe(1);
+        parsedData.Count(trade => trade.AcquisitionDisposal == TradeType.DISPOSAL).ShouldBe(1);
+        parsedData.ShouldAllBe(trade => trade.AssetName == "FUNDA");
+        parsedData.First().Isin.ShouldBe("IE0000000001");
     }
 
     [Fact]

--- a/UnitTest/Test/resource/TaxExample.xml
+++ b/UnitTest/Test/resource/TaxExample.xml
@@ -14,6 +14,10 @@
 				<Order currency="USD" fxRateToBase="0.86" assetCategory="STK" symbol="ABC" isin="US9999999999" description="ABC Example Stock" dateTime="04-May-21 12:34:56" quantity="100" proceeds="-600" taxes="-50" ibCommission="-1.5" ibCommissionCurrency="USD" notes="O" buySell="BUY" levelOfDetail="ORDER" />
 				<Order currency="USD" fxRateToBase="0.86" assetCategory="STK" symbol="DEF" isin="GB0000000000" description="DEF Example Stock" dateTime="05-May-21 12:34:56" quantity="-100" proceeds="1000" taxes="0" ibCommission="-1.5" ibCommissionCurrency="USD" notes="O" buySell="SELL" levelOfDetail="ORDER" />
 				<Order currency="USD" fxRateToBase="0.86" assetCategory="STK" symbol="DEF" isin="GB0000000000" description="DEF Example Stock" dateTime="06-Dec-21 12:34:56" quantity="100" proceeds="-500" taxes="0" ibCommission="-1.5" ibCommissionCurrency="USD" notes="C" buySell="BUY" levelOfDetail="ORDER" />
+
+				<!-- Fund (ETF/Mutual fund) trades -->
+				<Order currency="USD" fxRateToBase="0.8" assetCategory="FUND" symbol="FUNDA" isin="IE0000000001" description="FUNDA Example Fund" dateTime="10-May-21 12:34:56" quantity="100" proceeds="-1000" taxes="0" ibCommission="-1.5" ibCommissionCurrency="USD" notes="O" buySell="BUY" levelOfDetail="ORDER" />
+				<Order currency="USD" fxRateToBase="0.85" assetCategory="FUND" symbol="FUNDA" isin="IE0000000001" description="FUNDA Example Fund" dateTime="10-Jun-21 12:34:56" quantity="-100" proceeds="1100" taxes="0" ibCommission="-1.5" ibCommissionCurrency="USD" notes="C" buySell="SELL" levelOfDetail="ORDER" />
 				<Order currency="JPY" fxRateToBase="0.006" assetCategory="FUT" symbol="NIYH3" isin="" description="NIY 10MAR23" dateTime="05-Mar-23 12:34:56" quantity="2" proceeds="-27000000" taxes="0" ibCommission="-700" ibCommissionCurrency="JPY" buySell="BUY" levelOfDetail="ORDER"/>
 				<Order currency="JPY" fxRateToBase="0.006" assetCategory="FUT" symbol="NIYH3" isin="" description="NIY 10MAR23" dateTime="07-Mar-23 12:34:56" quantity="-2" proceeds="29000000" taxes="0" ibCommission="-800" ibCommissionCurrency="JPY" buySell="SELL" levelOfDetail="ORDER"/>
 


### PR DESCRIPTION
IBKR reports mutual funds and some ETFs with assetCategory="FUND",
which previously required editing the XML to "STK" to be picked up.

- Add FUND to AssetCategoryType, mapped to the HMRC listed shares
  category so fund disposals report under listed securities
- Parse assetCategory="FUND" orders from IBKR flex statements,
  tagged with the FUND asset type
- Add "Load Funds" import option (IB XML parsing and JSON re-import)
- Route FUND trades through the stock trade calculator so same day,
  bed and breakfast and Section 104 matching apply
- Include fund tickers in asset name selection for dividends, interest
  income, ERI, equalisation and corporate action entry; fund dividends
  remain convertible to income on the convert page

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015ZaXJhjqEFE72chvUd3rKA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing and processing fund trades, including ETFs and mutual funds.
  * Added an option to load fund trades from Interactive Brokers data.
  * Fund assets are now available in trade selection, manual entries, corporate actions, equalisation, and related workflows.
  * Fund transactions are classified as listed shares for tax calculations.

* **Documentation**
  * Updated supported trade types and fund order details in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->