### PR TITLE
Limit PDF company information section to companies relevant to the ta…

### DIFF
--- a/BlazorApp-Investment Tax Calculator/InvestmentTaxCalculator.csproj
+++ b/BlazorApp-Investment Tax Calculator/InvestmentTaxCalculator.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
 	<PublishTrimmed>true</PublishTrimmed>
 	<BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BlazorApp-Investment Tax Calculator/Services/PdfExport/PdfExportService.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/PdfExport/PdfExportService.cs
@@ -25,7 +25,7 @@ public class PdfExportService
         ISection dividendSummarySection = new DividendSummarySection(dividendCalculationResult);
         ISection disposalDetailSection = new DisposalDetailSection(tradeCalculationResult);
         ISection interestIncomeSummarySection = new InterestIncomeSummarySection(dividendCalculationResult);
-        ISection companyInformationSection = new CompanyInformationSection(shareIdentityRegistry, taxEventLists, taxYearConverter, uKSection104Pools);
+        ISection companyInformationSection = new CompanyInformationSection(shareIdentityRegistry, taxEventLists, taxYearConverter, uKSection104Pools, tradeCalculationResult);
         AllSections = [
             yearSummarySection,
             dividendSummarySection,

--- a/BlazorApp-Investment Tax Calculator/Services/PdfExport/PdfExportService.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/PdfExport/PdfExportService.cs
@@ -1,4 +1,5 @@
 using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model.Interfaces;
 using InvestmentTaxCalculator.Model.UkTaxModel;
 using InvestmentTaxCalculator.Services.PdfExport.Sections;
 
@@ -14,7 +15,8 @@ public class PdfExportService
     public List<ISection> AllSections { get; set; }
     public string[]? SelectedSections { get; set; }
     public PdfExportService(TaxYearReportService taxYearReportService, TradeCalculationResult tradeCalculationResult,
-        UkSection104Pools uKSection104Pools, DividendCalculationResult dividendCalculationResult, ShareIdentityRegistry shareIdentityRegistry)
+        UkSection104Pools uKSection104Pools, DividendCalculationResult dividendCalculationResult, ShareIdentityRegistry shareIdentityRegistry,
+        TaxEventLists taxEventLists, ITaxYear taxYearConverter)
     {
         ISection yearSummarySection = new YearlyTaxSummarySection(tradeCalculationResult, taxYearReportService);
         ISection allTradesListSection = new AllTradesListInYearSection(tradeCalculationResult);
@@ -23,7 +25,7 @@ public class PdfExportService
         ISection dividendSummarySection = new DividendSummarySection(dividendCalculationResult);
         ISection disposalDetailSection = new DisposalDetailSection(tradeCalculationResult);
         ISection interestIncomeSummarySection = new InterestIncomeSummarySection(dividendCalculationResult);
-        ISection companyInformationSection = new CompanyInformationSection(shareIdentityRegistry);
+        ISection companyInformationSection = new CompanyInformationSection(shareIdentityRegistry, taxEventLists, taxYearConverter, uKSection104Pools);
         AllSections = [
             yearSummarySection,
             dividendSummarySection,

--- a/BlazorApp-Investment Tax Calculator/Services/PdfExport/Sections/CompanyInformationSection.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/PdfExport/Sections/CompanyInformationSection.cs
@@ -1,4 +1,7 @@
 using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model.Interfaces;
+using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Model.UkTaxModel;
 
 using MigraDoc.DocumentObjectModel;
 using MigraDoc.DocumentObjectModel.Tables;
@@ -6,11 +9,14 @@ using MigraDoc.DocumentObjectModel.Tables;
 namespace InvestmentTaxCalculator.Services.PdfExport.Sections;
 
 /// <summary>
-/// Lists the identity of each company/share in the imported data: the name used in the report, the full company
-/// name(s), and every ticker/ISIN combination with the date it was last seen, so renames, Newco insertions and
-/// exchange suffix variations are documented in the report.
+/// Lists the identity of each company/share relevant to the reported tax year: the name used in the report, the
+/// full company name(s), and every ticker/ISIN combination with the date it was last seen, so renames, Newco
+/// insertions and exchange suffix variations are documented in the report. A company is relevant when it has a
+/// tax event dated in the tax year or is still held in a Section 104 pool at the end of it, so the section stays
+/// limited to companies appearing elsewhere in the report instead of every company ever imported.
 /// </summary>
-public class CompanyInformationSection(ShareIdentityRegistry shareIdentityRegistry) : ISection
+public class CompanyInformationSection(ShareIdentityRegistry shareIdentityRegistry, TaxEventLists taxEventLists,
+    ITaxYear taxYearConverter, UkSection104Pools section104Pools) : ISection
 {
     public string Name { get; set; } = "Company Information";
     public string Title { get; set; } = "Company Information";
@@ -20,17 +26,20 @@ public class CompanyInformationSection(ShareIdentityRegistry shareIdentityRegist
         Paragraph paragraph = section.AddParagraph(Title);
         Style.StyleTitle(paragraph);
 
+        HashSet<ShareIdentity> relevantIdentities = GetIdentitiesRelevantToTaxYear(taxYear);
         List<ShareIdentity> identities = [.. shareIdentityRegistry.Identities
+            .Where(relevantIdentities.Contains)
             .Where(identity => identity.Isins.Count > 0 || identity.FullNames.Count > 0 || identity.Tickers.Count > 1)
             .OrderBy(identity => identity.UniqueTicker, StringComparer.OrdinalIgnoreCase)];
 
         if (identities.Count == 0)
         {
-            section.AddParagraph("No company information is available.");
+            section.AddParagraph("No company information is available for this tax year.");
             return section;
         }
 
-        section.AddParagraph("Tickers and ISINs of the same company are listed together with the date each " +
+        section.AddParagraph("Companies with a tax event in this tax year or still held at the end of it are " +
+            "listed. Tickers and ISINs of the same company are listed together with the date each " +
             "combination was last seen in the imported data, so the entry with the latest date is the current " +
             "ticker/ISIN and earlier entries are former ones (e.g. before a rename or Newco insertion).");
 
@@ -68,5 +77,30 @@ public class CompanyInformationSection(ShareIdentityRegistry shareIdentityRegist
             }
         }
         return section;
+    }
+
+    /// <summary>
+    /// The identities with a tax event dated in the given tax year, plus those still held in a Section 104 pool at
+    /// the end of it (a held company appears in the Section 104 status section even without any event that year).
+    /// </summary>
+    private HashSet<ShareIdentity> GetIdentitiesRelevantToTaxYear(int taxYear)
+    {
+        HashSet<ShareIdentity> relevantIdentities = [];
+        foreach (TaxEvent taxEvent in taxEventLists.AllEvents)
+        {
+            if (taxEvent.ShareIdentity is not null && taxYearConverter.ToTaxYear(taxEvent.Date) == taxYear)
+            {
+                relevantIdentities.Add(taxEvent.ShareIdentity);
+            }
+        }
+        foreach (string assetName in section104Pools.GetEndOfYearSection104s(taxYear).Keys)
+        {
+            ShareIdentity? identity = shareIdentityRegistry.ResolveByTicker(assetName);
+            if (identity is not null)
+            {
+                relevantIdentities.Add(identity);
+            }
+        }
+        return relevantIdentities;
     }
 }

--- a/BlazorApp-Investment Tax Calculator/Services/PdfExport/Sections/CompanyInformationSection.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/PdfExport/Sections/CompanyInformationSection.cs
@@ -16,7 +16,7 @@ namespace InvestmentTaxCalculator.Services.PdfExport.Sections;
 /// limited to companies appearing elsewhere in the report instead of every company ever imported.
 /// </summary>
 public class CompanyInformationSection(ShareIdentityRegistry shareIdentityRegistry, TaxEventLists taxEventLists,
-    ITaxYear taxYearConverter, UkSection104Pools section104Pools) : ISection
+    ITaxYear taxYearConverter, UkSection104Pools section104Pools, TradeCalculationResult tradeCalculationResult) : ISection
 {
     public string Name { get; set; } = "Company Information";
     public string Title { get; set; } = "Company Information";
@@ -80,27 +80,45 @@ public class CompanyInformationSection(ShareIdentityRegistry shareIdentityRegist
     }
 
     /// <summary>
-    /// The identities with a tax event dated in the given tax year, plus those still held in a Section 104 pool at
-    /// the end of it (a held company appears in the Section 104 status section even without any event that year).
+    /// The identities with a tax event dated in the given tax year (for a corporate action, every company the
+    /// action affects - e.g. the acquiring company of a takeover - not just the company it is recorded against),
+    /// plus those whose calculated trades are reported in the tax year (a disposal made while temporarily
+    /// non-resident is reported in the year residency resumes, not the year of its trade date), plus those still
+    /// held in a Section 104 pool at the end of the year (a held company appears in the Section 104 status
+    /// section even without any event that year).
     /// </summary>
     private HashSet<ShareIdentity> GetIdentitiesRelevantToTaxYear(int taxYear)
     {
         HashSet<ShareIdentity> relevantIdentities = [];
         foreach (TaxEvent taxEvent in taxEventLists.AllEvents)
         {
-            if (taxEvent.ShareIdentity is not null && taxYearConverter.ToTaxYear(taxEvent.Date) == taxYear)
+            if (taxYearConverter.ToTaxYear(taxEvent.Date) != taxYear) continue;
+            if (taxEvent.ShareIdentity is not null)
             {
                 relevantIdentities.Add(taxEvent.ShareIdentity);
             }
-        }
-        foreach (string assetName in section104Pools.GetEndOfYearSection104s(taxYear).Keys)
-        {
-            ShareIdentity? identity = shareIdentityRegistry.ResolveByTicker(assetName);
-            if (identity is not null)
+            if (taxEvent is CorporateAction corporateAction)
             {
-                relevantIdentities.Add(identity);
+                AddResolvedIdentities(relevantIdentities, corporateAction.CompanyTickersInProcessingOrder);
             }
         }
+        AddResolvedIdentities(relevantIdentities, tradeCalculationResult.TradeByYear
+            .Where(tradesByYear => tradesByYear.Key.Item1 == taxYear)
+            .SelectMany(tradesByYear => tradesByYear.Value)
+            .Select(calculation => calculation.AssetName));
+        AddResolvedIdentities(relevantIdentities, section104Pools.GetEndOfYearSection104s(taxYear).Keys);
         return relevantIdentities;
+    }
+
+    private void AddResolvedIdentities(HashSet<ShareIdentity> identities, IEnumerable<string> tickers)
+    {
+        foreach (string ticker in tickers)
+        {
+            ShareIdentity? identity = shareIdentityRegistry.ResolveByTicker(ticker);
+            if (identity is not null)
+            {
+                identities.Add(identity);
+            }
+        }
     }
 }

--- a/UnitTest/Test/Services/CompanyInformationSectionTest.cs
+++ b/UnitTest/Test/Services/CompanyInformationSectionTest.cs
@@ -1,0 +1,122 @@
+using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Model.UkTaxModel;
+using InvestmentTaxCalculator.Services;
+using InvestmentTaxCalculator.Services.PdfExport.Sections;
+
+using MigraDoc.DocumentObjectModel;
+using MigraDoc.DocumentObjectModel.Tables;
+
+using System.Globalization;
+
+namespace UnitTest.Test.Services;
+
+public class CompanyInformationSectionTest
+{
+    [Fact]
+    public void TestOnlyCompaniesWithEventsInTheTaxYearAreListed()
+    {
+        TaxEventLists taxEventLists = new();
+        taxEventLists.Trades.Add(CreateTrade("ABC", "GB00AAAAAAAA", "01-May-21 10:00:00"));
+        taxEventLists.Trades.Add(CreateTrade("XYZ", "US00BBBBBBBB", "01-May-19 10:00:00"));
+        (CompanyInformationSection companyInformationSection, _, _) = CreateSection(taxEventLists);
+
+        List<string> listedTickers = GetListedTickers(companyInformationSection, 2021);
+
+        listedTickers.ShouldBe(["ABC"]);
+    }
+
+    [Fact]
+    public void TestDividendInTaxYearMakesCompanyListed()
+    {
+        TaxEventLists taxEventLists = new();
+        taxEventLists.Trades.Add(CreateTrade("ABC", "GB00AAAAAAAA", "01-May-19 10:00:00"));
+        taxEventLists.Dividends.Add(CreateDividend("ABC", "GB00AAAAAAAA", "01-Jun-21 10:00:00"));
+        (CompanyInformationSection companyInformationSection, _, _) = CreateSection(taxEventLists);
+
+        GetListedTickers(companyInformationSection, 2021).ShouldBe(["ABC"]);
+        GetListedTickers(companyInformationSection, 2019).ShouldBe(["ABC"]);
+        GetListedTickers(companyInformationSection, 2020).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void TestCompanyStillHeldAtEndOfTaxYearIsListedWithoutEventsInYear()
+    {
+        TaxEventLists taxEventLists = new();
+        taxEventLists.Trades.Add(CreateTrade("HLD", "GB00CCCCCCCC", "01-May-19 10:00:00"));
+        (CompanyInformationSection companyInformationSection, _, UkSection104Pools section104Pools) = CreateSection(taxEventLists);
+        section104Pools.GetExistingOrInitialise("HLD")
+            .AddAssets(DateTime.Parse("01-May-19 10:00:00", CultureInfo.InvariantCulture), 10, new WrappedMoney(100, "GBP"));
+
+        GetListedTickers(companyInformationSection, 2021).ShouldBe(["HLD"]);
+    }
+
+    [Fact]
+    public void TestCompanyDisposedInEarlierTaxYearIsNotListed()
+    {
+        TaxEventLists taxEventLists = new();
+        taxEventLists.Trades.Add(CreateTrade("SLD", "GB00DDDDDDDD", "01-May-19 10:00:00"));
+        (CompanyInformationSection companyInformationSection, _, UkSection104Pools section104Pools) = CreateSection(taxEventLists);
+        UkSection104 section104 = section104Pools.GetExistingOrInitialise("SLD");
+        section104.AddAssets(DateTime.Parse("01-May-19 10:00:00", CultureInfo.InvariantCulture), 10, new WrappedMoney(100, "GBP"));
+        section104.ClearSection104(DateTime.Parse("01-Jun-19 10:00:00", CultureInfo.InvariantCulture), "Disposed");
+
+        GetListedTickers(companyInformationSection, 2021).ShouldBeEmpty();
+        GetListedTickers(companyInformationSection, 2019).ShouldBe(["SLD"]);
+    }
+
+    private static (CompanyInformationSection Section, ShareIdentityRegistry Registry, UkSection104Pools Pools) CreateSection(TaxEventLists taxEventLists)
+    {
+        ShareIdentityRegistry shareIdentityRegistry = new();
+        shareIdentityRegistry.RegisterEvents(taxEventLists.AllEvents);
+        UKTaxYear ukTaxYear = new();
+        UkSection104Pools section104Pools = new(ukTaxYear, new ResidencyStatusRecord(), shareIdentityRegistry);
+        CompanyInformationSection companyInformationSection = new(shareIdentityRegistry, taxEventLists, ukTaxYear, section104Pools);
+        return (companyInformationSection, shareIdentityRegistry, section104Pools);
+    }
+
+    /// <summary>
+    /// Write the section for the given tax year and return the "Name in report" column of the company table,
+    /// or an empty list when the section shows no table.
+    /// </summary>
+    private static List<string> GetListedTickers(CompanyInformationSection companyInformationSection, int taxYear)
+    {
+        Document document = new();
+        Section section = document.AddSection();
+        companyInformationSection.WriteSection(section, taxYear);
+        Table? table = section.Elements.OfType<Table>().FirstOrDefault();
+        if (table is null) return [];
+        return [.. table.Rows.Cast<Row>()
+            .Skip(1) // header row
+            .Select(row => string.Concat(row.Cells[0].Elements.OfType<Paragraph>()
+                .SelectMany(paragraph => paragraph.Elements.OfType<Text>())
+                .Select(text => text.Content)))
+            .Where(ticker => !string.IsNullOrEmpty(ticker))];
+    }
+
+    private static Trade CreateTrade(string assetName, string isin, string date)
+    {
+        return new Trade
+        {
+            AssetName = assetName,
+            Isin = isin,
+            Date = DateTime.Parse(date, CultureInfo.InvariantCulture),
+            Quantity = 10,
+            GrossProceed = new DescribedMoney(100, "GBP", 1),
+            AcquisitionDisposal = TradeType.ACQUISITION
+        };
+    }
+
+    private static Dividend CreateDividend(string assetName, string isin, string date)
+    {
+        return new Dividend
+        {
+            AssetName = assetName,
+            Isin = isin,
+            Date = DateTime.Parse(date, CultureInfo.InvariantCulture),
+            DividendType = DividendType.DIVIDEND,
+            Proceed = new DescribedMoney(100, "GBP", 1)
+        };
+    }
+}

--- a/UnitTest/Test/Services/CompanyInformationSectionTest.cs
+++ b/UnitTest/Test/Services/CompanyInformationSectionTest.cs
@@ -87,6 +87,25 @@ public class CompanyInformationSectionTest
     }
 
     [Fact]
+    public void TestTemporaryNonResidentAcquisitionListsCompanyInTheReportedTaxYear()
+    {
+        // An acquisition made while temporarily non-resident is grouped into the residency-resumption year and
+        // appears in that year's "List of all trades" section, so its company belongs in that year's company
+        // information too. Relevance therefore deliberately covers all calculated trades, not only disposals.
+        TaxEventLists taxEventLists = new();
+        Trade acquisitionTrade = CreateTrade("TNA", "GB00HHHHHHHH", "01-May-20 10:00:00");
+        taxEventLists.Trades.Add(acquisitionTrade);
+        (CompanyInformationSection companyInformationSection, _, _, TradeCalculationResult tradeCalculationResult,
+            ResidencyStatusRecord residencyStatusRecord) = CreateSection(taxEventLists);
+        residencyStatusRecord.SetResidencyStatus(new DateOnly(2019, 4, 6), new DateOnly(2023, 4, 5), ResidencyStatus.TemporaryNonResident);
+        TradeTaxCalculation calculation = new([acquisitionTrade]) { ResidencyStatusAtTrade = ResidencyStatus.TemporaryNonResident };
+        tradeCalculationResult.SetResult([calculation]);
+
+        GetListedTickers(companyInformationSection, 2023).ShouldBe(["TNA"]);
+        GetListedTickers(companyInformationSection, 2021).ShouldBeEmpty();
+    }
+
+    [Fact]
     public void TestTakeoverListsAcquiringCompanyInTheTaxYear()
     {
         // A takeover affects the acquiring company's Section 104 pool in the year of the action, so both companies

--- a/UnitTest/Test/Services/CompanyInformationSectionTest.cs
+++ b/UnitTest/Test/Services/CompanyInformationSectionTest.cs
@@ -2,6 +2,7 @@ using InvestmentTaxCalculator.Enumerations;
 using InvestmentTaxCalculator.Model;
 using InvestmentTaxCalculator.Model.TaxEvents;
 using InvestmentTaxCalculator.Model.UkTaxModel;
+using InvestmentTaxCalculator.Model.UkTaxModel.Stocks;
 using InvestmentTaxCalculator.Services;
 using InvestmentTaxCalculator.Services.PdfExport.Sections;
 
@@ -20,7 +21,7 @@ public class CompanyInformationSectionTest
         TaxEventLists taxEventLists = new();
         taxEventLists.Trades.Add(CreateTrade("ABC", "GB00AAAAAAAA", "01-May-21 10:00:00"));
         taxEventLists.Trades.Add(CreateTrade("XYZ", "US00BBBBBBBB", "01-May-19 10:00:00"));
-        (CompanyInformationSection companyInformationSection, _, _) = CreateSection(taxEventLists);
+        (CompanyInformationSection companyInformationSection, _, _, _, _) = CreateSection(taxEventLists);
 
         List<string> listedTickers = GetListedTickers(companyInformationSection, 2021);
 
@@ -33,7 +34,7 @@ public class CompanyInformationSectionTest
         TaxEventLists taxEventLists = new();
         taxEventLists.Trades.Add(CreateTrade("ABC", "GB00AAAAAAAA", "01-May-19 10:00:00"));
         taxEventLists.Dividends.Add(CreateDividend("ABC", "GB00AAAAAAAA", "01-Jun-21 10:00:00"));
-        (CompanyInformationSection companyInformationSection, _, _) = CreateSection(taxEventLists);
+        (CompanyInformationSection companyInformationSection, _, _, _, _) = CreateSection(taxEventLists);
 
         GetListedTickers(companyInformationSection, 2021).ShouldBe(["ABC"]);
         GetListedTickers(companyInformationSection, 2019).ShouldBe(["ABC"]);
@@ -45,7 +46,7 @@ public class CompanyInformationSectionTest
     {
         TaxEventLists taxEventLists = new();
         taxEventLists.Trades.Add(CreateTrade("HLD", "GB00CCCCCCCC", "01-May-19 10:00:00"));
-        (CompanyInformationSection companyInformationSection, _, UkSection104Pools section104Pools) = CreateSection(taxEventLists);
+        (CompanyInformationSection companyInformationSection, _, UkSection104Pools section104Pools, _, _) = CreateSection(taxEventLists);
         section104Pools.GetExistingOrInitialise("HLD")
             .AddAssets(DateTime.Parse("01-May-19 10:00:00", CultureInfo.InvariantCulture), 10, new WrappedMoney(100, "GBP"));
 
@@ -57,7 +58,7 @@ public class CompanyInformationSectionTest
     {
         TaxEventLists taxEventLists = new();
         taxEventLists.Trades.Add(CreateTrade("SLD", "GB00DDDDDDDD", "01-May-19 10:00:00"));
-        (CompanyInformationSection companyInformationSection, _, UkSection104Pools section104Pools) = CreateSection(taxEventLists);
+        (CompanyInformationSection companyInformationSection, _, UkSection104Pools section104Pools, _, _) = CreateSection(taxEventLists);
         UkSection104 section104 = section104Pools.GetExistingOrInitialise("SLD");
         section104.AddAssets(DateTime.Parse("01-May-19 10:00:00", CultureInfo.InvariantCulture), 10, new WrappedMoney(100, "GBP"));
         section104.ClearSection104(DateTime.Parse("01-Jun-19 10:00:00", CultureInfo.InvariantCulture), "Disposed");
@@ -66,14 +67,58 @@ public class CompanyInformationSectionTest
         GetListedTickers(companyInformationSection, 2019).ShouldBe(["SLD"]);
     }
 
-    private static (CompanyInformationSection Section, ShareIdentityRegistry Registry, UkSection104Pools Pools) CreateSection(TaxEventLists taxEventLists)
+    [Fact]
+    public void TestTemporaryNonResidentDisposalListsCompanyInTheReportedTaxYear()
+    {
+        // A disposal made while temporarily non-resident is taxed (and reported) in the year residency resumes,
+        // so the company belongs in that report year's company information even though the trade date is earlier.
+        TaxEventLists taxEventLists = new();
+        Trade disposalTrade = CreateTrade("TNR", "GB00EEEEEEEE", "01-May-20 10:00:00", TradeType.DISPOSAL);
+        taxEventLists.Trades.Add(disposalTrade);
+        (CompanyInformationSection companyInformationSection, _, _, TradeCalculationResult tradeCalculationResult,
+            ResidencyStatusRecord residencyStatusRecord) = CreateSection(taxEventLists);
+        residencyStatusRecord.SetResidencyStatus(new DateOnly(2019, 4, 6), new DateOnly(2023, 4, 5), ResidencyStatus.TemporaryNonResident);
+        TradeTaxCalculation calculation = new([disposalTrade]) { ResidencyStatusAtTrade = ResidencyStatus.TemporaryNonResident };
+        tradeCalculationResult.SetResult([calculation]);
+
+        GetListedTickers(companyInformationSection, 2023).ShouldBe(["TNR"]);
+        GetListedTickers(companyInformationSection, 2020).ShouldBe(["TNR"]);
+        GetListedTickers(companyInformationSection, 2021).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void TestTakeoverListsAcquiringCompanyInTheTaxYear()
+    {
+        // A takeover affects the acquiring company's Section 104 pool in the year of the action, so both companies
+        // belong in that year's company information even when the acquiring company has no tax event of its own.
+        TaxEventLists taxEventLists = new();
+        taxEventLists.Trades.Add(CreateTrade("OLD", "GB00FFFFFFFF", "01-May-19 10:00:00"));
+        taxEventLists.Trades.Add(CreateTrade("ACQ", "GB00GGGGGGGG", "01-May-19 10:00:00"));
+        taxEventLists.CorporateActions.Add(new TakeoverCorporateAction
+        {
+            AssetName = "OLD",
+            Date = DateTime.Parse("01-May-21 10:00:00", CultureInfo.InvariantCulture),
+            AcquiringCompanyTicker = "ACQ",
+            OldToNewRatio = 1m
+        });
+        (CompanyInformationSection companyInformationSection, _, _, _, _) = CreateSection(taxEventLists);
+
+        GetListedTickers(companyInformationSection, 2021).ShouldBe(["ACQ", "OLD"]);
+        GetListedTickers(companyInformationSection, 2020).ShouldBeEmpty();
+    }
+
+    private static (CompanyInformationSection Section, ShareIdentityRegistry Registry, UkSection104Pools Pools,
+        TradeCalculationResult TradeCalculationResult, ResidencyStatusRecord ResidencyStatusRecord) CreateSection(TaxEventLists taxEventLists)
     {
         ShareIdentityRegistry shareIdentityRegistry = new();
         shareIdentityRegistry.RegisterEvents(taxEventLists.AllEvents);
         UKTaxYear ukTaxYear = new();
-        UkSection104Pools section104Pools = new(ukTaxYear, new ResidencyStatusRecord(), shareIdentityRegistry);
-        CompanyInformationSection companyInformationSection = new(shareIdentityRegistry, taxEventLists, ukTaxYear, section104Pools);
-        return (companyInformationSection, shareIdentityRegistry, section104Pools);
+        ResidencyStatusRecord residencyStatusRecord = new();
+        UkSection104Pools section104Pools = new(ukTaxYear, residencyStatusRecord, shareIdentityRegistry);
+        TradeCalculationResult tradeCalculationResult = new(ukTaxYear, residencyStatusRecord);
+        CompanyInformationSection companyInformationSection = new(shareIdentityRegistry, taxEventLists, ukTaxYear,
+            section104Pools, tradeCalculationResult);
+        return (companyInformationSection, shareIdentityRegistry, section104Pools, tradeCalculationResult, residencyStatusRecord);
     }
 
     /// <summary>
@@ -95,7 +140,7 @@ public class CompanyInformationSectionTest
             .Where(ticker => !string.IsNullOrEmpty(ticker))];
     }
 
-    private static Trade CreateTrade(string assetName, string isin, string date)
+    private static Trade CreateTrade(string assetName, string isin, string date, TradeType tradeType = TradeType.ACQUISITION)
     {
         return new Trade
         {
@@ -104,7 +149,7 @@ public class CompanyInformationSectionTest
             Date = DateTime.Parse(date, CultureInfo.InvariantCulture),
             Quantity = 10,
             GrossProceed = new DescribedMoney(100, "GBP", 1),
-            AcquisitionDisposal = TradeType.ACQUISITION
+            AcquisitionDisposal = tradeType
         };
     }
 


### PR DESCRIPTION
…x year

The section previously listed every company ever imported, so the table grew unbounded across tax years. It now lists only companies with a tax event dated in the reported tax year, plus companies still held in a Section 104 pool at the end of that year (they appear in the Section 104 status section even without events that year).


Claude-Session: https://claude.ai/code/session_019KKKvyhqpcW1pQsYCuWsvQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * PDF reports now include companies associated with tax events, corporate actions, relevant trades, and year-end holdings for the selected tax year.
  * Takeover reports now list both the acquiring and acquired companies.

* **Bug Fixes**
  * Temporary non-resident disposals are now reported in the tax year when residency resumes.

* **Chores**
  * Updated the application version to 1.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->