### PR TITLE
Fix share identity link and display name for exchange suffixed renames

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Components/ImportedTradesList.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ImportedTradesList.razor
@@ -4,6 +4,8 @@
 @using InvestmentTaxCalculator.Services
 
 @inject ITradeAndCorporateActionList _taxEventLists
+@inject TaxEventLists _allTaxEventLists
+@inject ShareIdentityRegistry _shareIdentityRegistry
 @inject ToastService _toastService
 
 <div class="card mt-4">
@@ -99,6 +101,9 @@
         if (removed)
         {
             _toastService.ShowInformation("Trade removed.");
+            // Deleting the last trade of a share must drop it from the share identities too, instead of leaving a
+            // stale entry (e.g. still selectable in the share identity link dropdowns) until the next calculation.
+            _shareIdentityRegistry.RegisterEvents(_allTaxEventLists.AllEvents);
             RefreshData();
             if (_grid != null)
             {

--- a/BlazorApp-Investment Tax Calculator/Components/ShareIdentityManager.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ShareIdentityManager.razor
@@ -125,7 +125,19 @@
         string reference = _linkReference1.Trim();
         string linkedReference = _linkReference2.Trim();
         ShareIdentityRegistry.LinkShares(reference, linkedReference);
-        ToastService.ShowInformation($"Linked {reference} and {linkedReference} as the same share. Run the calculation again to apply.");
+        // A link only takes effect when both references resolve to an imported share, so warn about typos and
+        // not-yet-imported tickers instead of storing a link that silently does nothing.
+        string? unresolvedReference = ShareIdentityRegistry.Resolve(reference) is null ? reference
+            : ShareIdentityRegistry.Resolve(linkedReference) is null ? linkedReference : null;
+        if (unresolvedReference is not null)
+        {
+            ToastService.ShowWarning($"Link saved, but \"{unresolvedReference}\" does not match any imported ticker or ISIN. " +
+                "The link will only take effect once data with that reference is imported.");
+        }
+        else
+        {
+            ToastService.ShowInformation($"Linked {reference} and {linkedReference} as the same share. Run the calculation again to apply.");
+        }
         _linkReference1 = string.Empty;
         _linkReference2 = string.Empty;
     }

--- a/BlazorApp-Investment Tax Calculator/Components/ShareIdentityManager.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/ShareIdentityManager.razor
@@ -19,12 +19,16 @@
 
         <div class="row g-2 align-items-end mb-3">
             <div class="col-md-4">
-                <label class="form-label" for="linkReference1">Ticker or ISIN</label>
-                <input id="linkReference1" class="form-control" @bind="_linkReference1" placeholder="e.g. OLDCO" />
+                <label class="form-label" for="linkReference1">Share</label>
+                <RadzenDropDown id="linkReference1" TValue="string" Data="@LinkOptions" TextProperty="Label" ValueProperty="Value"
+                                @bind-Value="_linkReference1" AllowFiltering="true" AllowClear="true"
+                                Placeholder="Select a ticker" class="w-100" />
             </div>
             <div class="col-md-4">
-                <label class="form-label" for="linkReference2">Same share as ticker or ISIN</label>
-                <input id="linkReference2" class="form-control" @bind="_linkReference2" placeholder="e.g. NEWCO or US1234567890" />
+                <label class="form-label" for="linkReference2">Same share as</label>
+                <RadzenDropDown id="linkReference2" TValue="string" Data="@LinkOptions" TextProperty="Label" ValueProperty="Value"
+                                @bind-Value="_linkReference2" AllowFiltering="true" AllowClear="true"
+                                Placeholder="Select a ticker" class="w-100" />
             </div>
             <div class="col-md-4">
                 <button class="btn btn-primary" @onclick="AddLink">Link shares</button>
@@ -79,6 +83,17 @@
     private string _linkReference1 = string.Empty;
     private string _linkReference2 = string.Empty;
 
+    private record LinkOption(string Value, string Label);
+
+    // One entry per share known to the registry, selectable by the name it is reported under. That name already
+    // carries the disambiguating ISIN when a ticker is recycled by an unrelated company (e.g. "ABC (GB00...)"),
+    // so the two shares can be told apart in the dropdown. The company name is appended for recognition.
+    private IEnumerable<LinkOption> LinkOptions => ShareIdentityRegistry.Identities
+        .Select(identity => new LinkOption(identity.UniqueTicker, identity.FullNames.Count > 0
+            ? $"{identity.UniqueTicker} — {string.Join("; ", identity.FullNames)}"
+            : identity.UniqueTicker))
+        .OrderBy(option => option.Label, StringComparer.OrdinalIgnoreCase);
+
     // Shares worth showing the user: those with more than one ticker or ISIN, plus those sharing a primary ticker
     // with another share (a recycled ticker, or the same ticker reissued under a new ISIN). The latter have a
     // single ticker and a single ISIN each, so they need listing explicitly - they are reported under an
@@ -119,16 +134,22 @@
     {
         if (string.IsNullOrWhiteSpace(_linkReference1) || string.IsNullOrWhiteSpace(_linkReference2))
         {
-            ToastService.ShowError("Please enter both share references to link.");
+            ToastService.ShowError("Please select both shares to link.");
             return;
         }
         string reference = _linkReference1.Trim();
         string linkedReference = _linkReference2.Trim();
+        ShareIdentity? identity = ShareIdentityRegistry.Resolve(reference);
+        ShareIdentity? linkedIdentity = ShareIdentityRegistry.Resolve(linkedReference);
+        if (identity is not null && ReferenceEquals(identity, linkedIdentity))
+        {
+            ToastService.ShowError("Both selections refer to the same share already - nothing to link.");
+            return;
+        }
         ShareIdentityRegistry.LinkShares(reference, linkedReference);
-        // A link only takes effect when both references resolve to an imported share, so warn about typos and
-        // not-yet-imported tickers instead of storing a link that silently does nothing.
-        string? unresolvedReference = ShareIdentityRegistry.Resolve(reference) is null ? reference
-            : ShareIdentityRegistry.Resolve(linkedReference) is null ? linkedReference : null;
+        // Selections come from the dropdown so they normally resolve, but a stored link only takes effect when
+        // both references match an imported share - warn instead of storing a link that silently does nothing.
+        string? unresolvedReference = identity is null ? reference : linkedIdentity is null ? linkedReference : null;
         if (unresolvedReference is not null)
         {
             ToastService.ShowWarning($"Link saved, but \"{unresolvedReference}\" does not match any imported ticker or ISIN. " +

--- a/BlazorApp-Investment Tax Calculator/InvestmentTaxCalculator.csproj
+++ b/BlazorApp-Investment Tax Calculator/InvestmentTaxCalculator.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
 	<PublishTrimmed>true</PublishTrimmed>
 	<BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BlazorApp-Investment Tax Calculator/Model/ShareIdentity.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/ShareIdentity.cs
@@ -50,7 +50,9 @@ public class ShareIdentity
     /// <summary>
     /// The single display/grouping name of this share:
     /// the common base symbol when all tickers only differ by a lowercase exchange suffix,
-    /// otherwise the most recently seen ticker (e.g. the new symbol after a rename).
+    /// otherwise the most recently seen ticker (e.g. the new symbol after a rename), again without its exchange
+    /// suffix - a rename observed only as a suffixed variation (e.g. "PHNX" renamed and seen as "SDLFl") must
+    /// display the new base symbol ("SDLF"), not the broker's suffixed spelling.
     /// </summary>
     public string PrimaryTicker
     {
@@ -60,8 +62,11 @@ public class ShareIdentity
             if (_tickers.Count == 1) return _tickers[0];
             List<string> baseSymbols = _tickers.Select(StripExchangeSuffix).Distinct().ToList();
             if (baseSymbols.Count == 1 && !string.IsNullOrEmpty(baseSymbols[0])) return baseSymbols[0];
-            return _tickers.OrderByDescending(ticker => _tickerLastSeen.GetValueOrDefault(ticker, DateTime.MinValue))
-                           .First();
+            string mostRecentTicker = _tickers
+                .OrderByDescending(ticker => _tickerLastSeen.GetValueOrDefault(ticker, DateTime.MinValue))
+                .First();
+            string mostRecentBaseSymbol = StripExchangeSuffix(mostRecentTicker);
+            return string.IsNullOrEmpty(mostRecentBaseSymbol) ? mostRecentTicker : mostRecentBaseSymbol;
         }
     }
 

--- a/BlazorApp-Investment Tax Calculator/Pages/AddExcessReportableIncome.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/AddExcessReportableIncome.razor
@@ -15,6 +15,7 @@
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JSRuntime
 @inject TaxCalculationService TaxCalculationService
+@inject ShareIdentityRegistry ShareIdentityRegistry
 
 <div class="container-fluid py-5">
     <div class="row">
@@ -162,6 +163,10 @@
     private void RefreshAll()
     {
         _dataChanged = true;
+        // ERI and equalisation entries (and the dividend/interest events ERI generates) go straight into
+        // TaxEventLists, so re-register the share identities instead of leaving them stale until the next
+        // calculation or file import.
+        ShareIdentityRegistry.RegisterEvents(TaxEventLists.AllEvents);
         RefreshHistory();
     }
 

--- a/BlazorApp-Investment Tax Calculator/Pages/AddMissingTradePage.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/AddMissingTradePage.razor
@@ -9,6 +9,7 @@
 @inject TaxEventLists TaxEventLists
 @inject TaxCalculationService TaxCalculationService
 @inject ManualEntryTrackerService ManualEntryTrackerService
+@inject ShareIdentityRegistry ShareIdentityRegistry
 @inject NavigationManager NavigationManager
 
 <div class="container-fluid py-5">
@@ -147,6 +148,7 @@
             _editingTaxEventId = null;
         }
         ManualEntryTrackerService.Add(taxEventId);
+        RefreshShareIdentities();
         RefreshAddedEntries();
         StateHasChanged();
     }
@@ -177,10 +179,16 @@
                 _editingTaxEventId = null;
             }
 
+            RefreshShareIdentities();
             RefreshAddedEntries();
             StateHasChanged();
         }
     }
+
+    // Manual entries go straight into TaxEventLists, so the share identities would otherwise stay stale until the
+    // next calculation or file import: a manually entered ticker would be missing everywhere identities are used,
+    // including the share identity link dropdowns. Re-register on every add, edit and delete, as importing does.
+    private void RefreshShareIdentities() => ShareIdentityRegistry.RegisterEvents(TaxEventLists.AllEvents);
 
     private void RefreshAddedEntries()
     {

--- a/BlazorApp-Investment Tax Calculator/Pages/TakeoverCorporateActionPage.razor
+++ b/BlazorApp-Investment Tax Calculator/Pages/TakeoverCorporateActionPage.razor
@@ -2,11 +2,14 @@
 
 @using InvestmentTaxCalculator.Components
 @using InvestmentTaxCalculator.Enumerations
+@using InvestmentTaxCalculator.Model
 @using InvestmentTaxCalculator.Model.TaxEvents
 @using StockSplitAction = InvestmentTaxCalculator.Model.TaxEvents.StockSplit
 @using InvestmentTaxCalculator.Services
 @implements IDisposable
 @inject TaxCalculationService _taxCalculationService
+@inject TaxEventLists _taxEventLists
+@inject ShareIdentityRegistry _shareIdentityRegistry
 @inject NavigationManager _navigationManager
 
 <div class="container-fluid py-5">
@@ -134,6 +137,10 @@
     {
         _hasChanges = true;
         _actionToEdit = null;
+        // Corporate actions go straight into TaxEventLists, so the share identities would otherwise stay stale
+        // until the next calculation or file import. The share identity link dropdowns live on this same page, so
+        // a ticker introduced by an action entered here must be selectable without leaving and recalculating.
+        _shareIdentityRegistry.RegisterEvents(_taxEventLists.AllEvents);
         if (_historyList is not null)
         {
             await _historyList.Refresh();

--- a/BlazorApp-Investment Tax Calculator/Services/ShareIdentityRegistry.cs
+++ b/BlazorApp-Investment Tax Calculator/Services/ShareIdentityRegistry.cs
@@ -92,12 +92,25 @@ public class ShareIdentityRegistry
     }
 
     /// <summary>
-    /// The identity holding the given ticker or ISIN, or null if unknown.
+    /// The identity holding the given ticker or ISIN, or null if unknown. A reference no identity holds directly
+    /// falls back to an exchange suffix insensitive match: users refer to a share by its base symbol (e.g. "SDLF")
+    /// while the imported data may only ever carry a suffixed variation (e.g. "SDLFl"), and a manual link typed
+    /// with the base symbol must still find that share. Only an unambiguous match counts - null when the base
+    /// symbol belongs to more than one share.
     /// </summary>
     public ShareIdentity? Resolve(string tickerOrIsin)
     {
         if (string.IsNullOrEmpty(tickerOrIsin)) return null;
-        return _identityByTicker.GetValueOrDefault(tickerOrIsin) ?? _identityByIsin.GetValueOrDefault(tickerOrIsin);
+        return _identityByTicker.GetValueOrDefault(tickerOrIsin)
+            ?? _identityByIsin.GetValueOrDefault(tickerOrIsin)
+            ?? ResolveByBaseSymbol(tickerOrIsin);
+    }
+
+    private ShareIdentity? ResolveByBaseSymbol(string baseSymbol)
+    {
+        List<ShareIdentity> matches = [.. _identities
+            .Where(identity => identity.Tickers.Any(ticker => ShareIdentity.StripExchangeSuffix(ticker) == baseSymbol))];
+        return matches.Count == 1 ? matches[0] : null;
     }
 
     /// <summary>

--- a/UnitTest/Test/Reproduction/Issue257RenamedTickerRepro.cs
+++ b/UnitTest/Test/Reproduction/Issue257RenamedTickerRepro.cs
@@ -1,0 +1,84 @@
+using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model.Interfaces;
+using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Model.UkTaxModel;
+using InvestmentTaxCalculator.Model.UkTaxModel.Stocks;
+using InvestmentTaxCalculator.Services;
+
+using NSubstitute;
+
+namespace UnitTest.Test.Reproduction;
+
+/// <summary>
+/// Issue #257 follow-up: a rename observed only as an exchange suffixed ticker ("PHNX" renamed and imported as
+/// "SDLFl"). Linking with the base symbol the user knows ("SDLF") used to be silently ignored, leaving two
+/// Section 104 pools and two End of Tax Year Section 104 Status rows; and once linked, the merged share was
+/// displayed as "SDLFl" instead of "SDLF".
+/// </summary>
+public class Issue257RenamedTickerRepro
+{
+    [Theory]
+    [InlineData("PHNX", "SDLF")]
+    [InlineData("PHNX", "SDLFl")]
+    [InlineData("GB00PHNX0001", "GB00SDLF0001")]
+    public void TestLinkedRenameConsolidatesEndOfYearSection104UnderBaseSymbol(string linkReference, string linkedReference)
+    {
+        Trade buyOld = CreateBuy("PHNX", "GB00PHNX0001", new DateTime(2020, 6, 1), 100m, 1000m);
+        Trade buyNew = CreateBuy("SDLFl", "GB00SDLF0001", new DateTime(2025, 7, 1), 50m, 500m);
+
+        ShareIdentityRegistry registry = new();
+        registry.RegisterEvents([buyOld, buyNew]);
+        registry.LinkShares(linkReference, linkedReference);
+        registry.RegisterEvents([buyOld, buyNew]);
+
+        registry.Identities.Count.ShouldBe(1);
+        buyOld.CanonicalAssetName.ShouldBe("SDLF");
+        buyNew.CanonicalAssetName.ShouldBe("SDLF");
+
+        ITradeAndCorporateActionList tradeList = Substitute.For<ITradeAndCorporateActionList>();
+        tradeList.Trades.Returns([buyOld, buyNew]);
+        tradeList.CorporateActions.Returns([]);
+        UkSection104Pools section104Pools = new(new UKTaxYear(), new ResidencyStatusRecord(), registry);
+        UkTradeCalculator calculator = new(section104Pools, tradeList,
+            new TradeTaxCalculationFactory(new ResidencyStatusRecord()), registry);
+        calculator.CalculateTax();
+
+        Dictionary<string, Section104History> endOfYear = section104Pools.GetEndOfYearSection104s(2025);
+        endOfYear.Keys.ShouldBe(["SDLF"]);
+        endOfYear["SDLF"].NewQuantity.ShouldBe(150m);
+        endOfYear["SDLF"].NewValue.ShouldBe(new WrappedMoney(1500m, "GBP"));
+    }
+
+    [Fact]
+    public void TestLinkByBaseSymbolIsNotAppliedWhenAmbiguous()
+    {
+        // Two unrelated shares both observed with suffixed variations of "ABC": a link typed as "ABC" cannot
+        // tell which one is meant, so it must not merge either of them.
+        Trade buyTarget = CreateBuy("XYZ", "GB00XYZ00001", new DateTime(2020, 6, 1), 100m, 1000m);
+        Trade buySuffixed = CreateBuy("ABCl", "GB00ABC00001", new DateTime(2021, 6, 1), 100m, 1000m);
+        Trade buyOtherSuffixed = CreateBuy("ABCm", "GB00ABC00002", new DateTime(2022, 6, 1), 100m, 1000m);
+
+        ShareIdentityRegistry registry = new();
+        registry.RegisterEvents([buyTarget, buySuffixed, buyOtherSuffixed]);
+        registry.LinkShares("XYZ", "ABC");
+        registry.RegisterEvents([buyTarget, buySuffixed, buyOtherSuffixed]);
+
+        registry.Identities.Count.ShouldBe(3);
+        registry.IsSameShare("XYZ", "ABCl").ShouldBeFalse();
+        registry.IsSameShare("XYZ", "ABCm").ShouldBeFalse();
+    }
+
+    private static Trade CreateBuy(string assetName, string isin, DateTime date, decimal quantity, decimal proceed)
+    {
+        return new Trade
+        {
+            AssetName = assetName,
+            Isin = isin,
+            Date = date,
+            AcquisitionDisposal = TradeType.ACQUISITION,
+            Quantity = quantity,
+            GrossProceed = new DescribedMoney(proceed, "GBP", 1m)
+        };
+    }
+}

--- a/UnitTest/Test/Services/ShareIdentityRegistryTest.cs
+++ b/UnitTest/Test/Services/ShareIdentityRegistryTest.cs
@@ -408,6 +408,32 @@ public class ShareIdentityRegistryTest
     }
 
     [Fact]
+    public void TestManuallyAddedEventIsAvailableAfterReRegistrationWithoutCalculating()
+    {
+        // Manual entry pages add straight to TaxEventLists and re-register, so a ticker entered by hand is known
+        // to the registry (and so selectable for a manual link) without waiting for the next calculation.
+        TaxEventLists taxEventLists = new();
+        taxEventLists.Trades.Add(CreateTrade("IMPORTED", "GB00IMPORTED"));
+        ShareIdentityRegistry registry = new();
+        registry.RegisterEvents(taxEventLists.AllEvents);
+        registry.ResolveByTicker("MANUAL").ShouldBeNull();
+
+        Trade manualTrade = CreateTrade("MANUAL", string.Empty, "01-Jun-22 10:00:00");
+        taxEventLists.Trades.Add(manualTrade);
+        registry.RegisterEvents(taxEventLists.AllEvents);
+
+        registry.ResolveByTicker("MANUAL").ShouldNotBeNull();
+        manualTrade.CanonicalAssetName.ShouldBe("MANUAL");
+        registry.Identities.Select(identity => identity.UniqueTicker).ShouldBe(["IMPORTED", "MANUAL"], ignoreOrder: true);
+
+        // Removing it again drops the identity, so a deleted entry does not linger.
+        taxEventLists.Trades.Remove(manualTrade);
+        registry.RegisterEvents(taxEventLists.AllEvents);
+        registry.ResolveByTicker("MANUAL").ShouldBeNull();
+        registry.Identities.Select(identity => identity.UniqueTicker).ShouldBe(["IMPORTED"]);
+    }
+
+    [Fact]
     public void TestUnknownTickerResolvesToItself()
     {
         ShareIdentityRegistry registry = new();

--- a/UnitTest/Test/Services/ShareIdentityRegistryTest.cs
+++ b/UnitTest/Test/Services/ShareIdentityRegistryTest.cs
@@ -247,6 +247,26 @@ public class ShareIdentityRegistryTest
     }
 
     [Fact]
+    public void TestManualLinkByBaseSymbolFindsSuffixOnlyTicker()
+    {
+        // The user knows the share by its base symbol, but the imported data may only carry an exchange suffixed
+        // variation (e.g. "SDLFl"). A link typed with the base symbol must still find and merge that share, and
+        // the merged share must display the new base symbol rather than the broker's suffixed spelling.
+        Trade oldTrade = CreateTrade("PHNX", "GB00PHNX0001", "01-May-21 10:00:00");
+        Trade newTrade = CreateTrade("SDLFl", "GB00SDLF0001", "01-May-25 10:00:00");
+        ShareIdentityRegistry registry = new();
+        registry.RegisterEvents([oldTrade, newTrade]);
+        registry.LinkShares("PHNX", "SDLF");
+        registry.RegisterEvents([oldTrade, newTrade]);
+
+        oldTrade.ShareIdentity.ShouldBeSameAs(newTrade.ShareIdentity);
+        registry.IsSameShare("PHNX", "SDLFl").ShouldBeTrue();
+        oldTrade.CanonicalAssetName.ShouldBe("SDLF");
+        newTrade.CanonicalAssetName.ShouldBe("SDLF");
+        registry.ResolveByTicker("SDLF").ShouldBeSameAs(oldTrade.ShareIdentity);
+    }
+
+    [Fact]
     public void TestManualLinkByIsinIsApplied()
     {
         Trade oldTrade = CreateTrade("OLDCO", "GB00B010V573");


### PR DESCRIPTION
Addresses points 1 and 3 of the follow-up feedback on #257: a share renamed and imported only under an exchange suffixed ticker (e.g. PHNX renamed and seen in the data as `SDLFl`) exposed two problems.

## Problems

1. **Two "End of Tax Year Section 104 Status" entries after linking.** A manual link typed with the base symbol (`SDLF`) — the spelling shown in reports and known to the user — did not resolve, because only the suffixed variation `SDLFl` was ever observed. The link was stored but silently ignored, leaving the old and new company as two identities and therefore two Section 104 pools and two end-of-year status rows.
2. **The merged share was named `SDLFl`.** When the merged tickers strip to different base symbols, `PrimaryTicker` fell back to the most recently seen ticker verbatim, keeping the broker's exchange suffix in the display/grouping name.

## Changes

- `ShareIdentityRegistry.Resolve` (the manual-link resolution path — its only callers) now falls back to an exchange-suffix-insensitive match, so `SDLF` finds the share observed as `SDLFl`. The fallback only applies when unambiguous: a base symbol matching more than one share resolves to nothing rather than guessing.
- `ShareIdentity.PrimaryTicker` strips the exchange suffix from the most recently seen ticker in the rename fallback, so the merged share reports as `SDLF` consistently across pools, PDF sections, and grids. Behavior for suffix-only variations (`CWR`/`CWRl`, `DIS`/`DISm`) and plain renames (`DWAC`→`DJT`) is unchanged.
- **The Share identities link UI now uses filterable dropdowns instead of free-text fields**, listing one entry per share known to the registry under the name it is reported under. A ticker recycled by an unrelated company appears with its disambiguating ISIN (e.g. `ABC (GB00...)`) so the two shares can be told apart, and the company name is appended for recognition. Selecting the same share twice is rejected, and a stored link whose reference no longer matches any imported share warns instead of silently doing nothing.
- **Share identities are now refreshed whenever tax events change in the UI.** Manual entries, corporate actions and ERI/equalisation entries were written straight into `TaxEventLists` without re-registering, so identities stayed stale until the next file import or calculation and a manually entered ticker was missing wherever identities are used — including the new link dropdowns. Registration is added at the three page-level seams that own those lifecycles (manual entry add/edit/delete, corporate action add/edit/delete, ERI and equalisation), plus the imported trades list so deleting the last trade of a share drops it rather than leaving a stale entry.
- Version bumped to 1.2.2.

## Tests

- `UnitTest/Test/Reproduction/Issue257RenamedTickerRepro.cs` runs the full stock calculator for all three link spellings (`SDLF`, `SDLFl`, ISINs) and asserts a single end-of-year Section 104 entry named `SDLF` with the combined quantity and value, plus a test that an ambiguous base-symbol link merges nothing.
- `TestManualLinkByBaseSymbolFindsSuffixOnlyTicker` and `TestManuallyAddedEventIsAvailableAfterReRegistrationWithoutCalculating` added alongside the other registry tests.
- Full unit suite passes: 352/352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KKKvyhqpcW1pQsYCuWsvQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share-link fields now offer filtered selections with identifying labels and company names.
  * Improved messages guide users to select shares when creating links.
  * Share selections refresh automatically after trades, income adjustments, and corporate actions change.

* **Bug Fixes**
  * Prevented shares from being linked to themselves.
  * Improved matching for renamed and exchange-suffixed tickers.
  * Prevented ambiguous matches from merging unrelated holdings.
  * Improved warnings for unresolved references.

* **Tests**
  * Added regression coverage for renamed tickers, suffixed symbols, ISIN links, and ambiguous matches.

* **Chores**
  * Incremented the application version to 1.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->