### PR TITLE
Preview a corporate action against the holding that preceded it

### DIFF
--- a/BlazorApp-Investment Tax Calculator/Components/CorporateActionHeader.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/CorporateActionHeader.razor
@@ -1,5 +1,7 @@
 @using InvestmentTaxCalculator.Model
+@using InvestmentTaxCalculator.Model.TaxEvents
 @using InvestmentTaxCalculator.Model.UkTaxModel
+@using InvestmentTaxCalculator.ViewModel
 @using InvestmentTaxCalculator.Services
 @using InvestmentTaxCalculator.Enumerations
 
@@ -23,17 +25,22 @@
                            Placeholder="Select Asset" />
         @if (!string.IsNullOrEmpty(SourceTicker))
         {
-            @if (_taxCalculationService.HasCurrentResult)
+            @if (_taxCalculationService.HasCurrentResult && CurrentHolding.HasValue)
             {
                 <div class="form-text text-info">
-                    Holding on @Date.ToShortDateString(): <strong>@CurrentHolding</strong> shares
+                    @HoldingLabel: <strong>@CurrentHolding.Value</strong> shares
                 </div>
-                <HoldingBreakdown AssetName="@SourceTicker" AsOfDate="@Date" />
+                @* While editing, the pool history still contains the action being edited, so a breakdown of it would
+                   not explain the figure above. It comes back once the edit is submitted and recalculated. *@
+                @if (ActionToEdit is null)
+                {
+                    <HoldingBreakdown AssetName="@SourceTicker" AsOfDate="@Date" />
+                }
             }
             else
             {
                 <div class="form-text text-warning">
-                    Holding on @Date.ToShortDateString(): <strong>Calculation pending</strong>
+                    @HoldingLabel: <strong>Calculation pending</strong>
                 </div>
             }
         }
@@ -109,7 +116,15 @@
     [Parameter] public decimal RatioMin { get; set; } = 0.0001m;
     [Parameter] public EventCallback OnInputsChanged { get; set; }
 
-    public decimal CurrentHolding { get; private set; }
+    /// <summary>The action this form is editing, so the holding is previewed against the state that preceded it.</summary>
+    [Parameter] public CorporateAction? ActionToEdit { get; set; }
+
+    /// <summary>Null when no holding can be shown; see <see cref="HoldingPreview.GetQuantity"/>.</summary>
+    public decimal? CurrentHolding { get; private set; }
+
+    private string HoldingLabel => ActionToEdit is null
+        ? $"Holding on {Date.ToShortDateString()}"
+        : $"Holding before this action on {Date.ToShortDateString()}";
 
     protected override void OnParametersSet()
     {
@@ -118,15 +133,7 @@
 
     private void CalculateStats()
     {
-        CurrentHolding = 0;
-        if (string.IsNullOrEmpty(SourceTicker)) return;
-
-        var history = _ukSection104Pools.GetExistingOrNull(SourceTicker!)?.GetLastSection104History(DateOnly.FromDateTime(Date));
-        
-        if (history != null) 
-        {
-            CurrentHolding = history.NewQuantity;
-        }
+        CurrentHolding = HoldingPreview.GetQuantity(_ukSection104Pools, SourceTicker, Date, ActionToEdit);
     }
 
     private async Task OnDateChangeInternal(DateTime? value)

--- a/BlazorApp-Investment Tax Calculator/Components/PartnerTransfer.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/PartnerTransfer.razor
@@ -4,6 +4,7 @@
 @using InvestmentTaxCalculator.Model.UkTaxModel
 @using InvestmentTaxCalculator.Enumerations
 @using InvestmentTaxCalculator.Services
+@using InvestmentTaxCalculator.ViewModel
 
 @inject UkSection104Pools _ukSection104Pools
 @inject TaxCalculationService _taxCalculationService
@@ -33,17 +34,22 @@
                                    Placeholder="Select or Enter Ticker" />
                 @if (!string.IsNullOrWhiteSpace(_ticker))
                 {
-                    @if (_taxCalculationService.HasCurrentResult)
+                    @if (_taxCalculationService.HasCurrentResult && _currentHolding.HasValue)
                     {
                         <div class="form-text text-info">
-                            Holding on @_date.ToShortDateString(): <strong>@_currentHolding.ToString("F4")</strong> shares
+                            @HoldingLabel: <strong>@_currentHolding.Value.ToString("F4")</strong> shares
                         </div>
-                        <HoldingBreakdown AssetName="@_ticker" AsOfDate="@_date" />
+                        @* While editing, the pool history still contains the transfer being edited, so a breakdown
+                           of it would not explain the figure above. *@
+                        @if (ActionToEdit is null)
+                        {
+                            <HoldingBreakdown AssetName="@_ticker" AsOfDate="@_date" />
+                        }
                     }
                     else
                     {
                         <div class="form-text text-warning">
-                            Holding on @_date.ToShortDateString(): <strong>Calculation pending</strong>
+                            @HoldingLabel: <strong>Calculation pending</strong>
                         </div>
                     }
                 }
@@ -96,7 +102,11 @@
     private decimal _transferredCostAmount = 0m;
     private string _transferredCostCurrency = "GBP";
     private decimal _transferredCostFx = 1m;
-    private decimal _currentHolding = 0m;
+    private decimal? _currentHolding;
+
+    private string HoldingLabel => ActionToEdit is null
+        ? $"Holding on {_date.ToShortDateString()}"
+        : $"Holding before this transfer on {_date.ToShortDateString()}";
     private List<CurrencyViewModel> _currencies = [];
     private PartnerTransferCorporateAction? _previousActionToEdit;
     private bool _isEditing => ActionToEdit != null;
@@ -163,9 +173,9 @@
 
     private void CalculateHolding()
     {
-        _currentHolding = 0m;
-        if (string.IsNullOrWhiteSpace(_ticker)) return;
-        _currentHolding = _ukSection104Pools.GetExistingOrNull(_ticker!)?.GetLastSection104History(DateOnly.FromDateTime(_date))?.NewQuantity ?? 0m;
+        // Editing previews against the holding before this transfer, otherwise a gift is validated against a pool
+        // it has already been deducted from and raising the gift is rejected against the reduced holding.
+        _currentHolding = HoldingPreview.GetQuantity(_ukSection104Pools, _ticker, _date, ActionToEdit);
     }
 
     private async Task Submit()
@@ -186,14 +196,14 @@
         if (Direction == PartnerTransferDirection.GiftToPartner)
         {
             // The holding only exists once the matching rules have run, so gifting cannot be checked before then.
-            if (!_taxCalculationService.HasCurrentResult)
+            if (!_taxCalculationService.HasCurrentResult || _currentHolding is null)
             {
                 _toastService.ShowError("Run the calculation so the holding available to gift is up to date.");
                 return;
             }
-            if (_quantity > _currentHolding)
+            if (_quantity > _currentHolding.Value)
             {
-                _toastService.ShowError($"Cannot gift {_quantity:0.####} shares because the holding is {_currentHolding:0.####} on {_date:d}.");
+                _toastService.ShowError($"Cannot gift {_quantity:0.####} shares because the holding is {_currentHolding.Value:0.####} on {_date:d}.");
                 return;
             }
         }

--- a/BlazorApp-Investment Tax Calculator/Components/Spinoff.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/Spinoff.razor
@@ -2,6 +2,7 @@
 @using InvestmentTaxCalculator.Model.TaxEvents
 @using InvestmentTaxCalculator.Model.UkTaxModel
 @using InvestmentTaxCalculator.Services
+@using InvestmentTaxCalculator.ViewModel
 @using InvestmentTaxCalculator.Model.Interfaces
 @using InvestmentTaxCalculator.Enumerations
 
@@ -37,13 +38,14 @@
                                @bind-SourceRatio="@_parentSharesRatio"
                                @bind-DestinationRatio="@_spinoffSharesRatio"
                                OnInputsChanged="CalculateStats"
+                               ActionToEdit="@ActionToEdit"
                                SourceLabel="Parent Company Asset"
                                DestinationLabel="Spinoff Company Ticker"
                                RatioLabel="Spinoff Ratio (Parent : Spinoff)"
                                SourceUnitLabel="shares of parent"
                                DestinationUnitLabel="shares of spinoff">
             <DestinationInfo>
-                Expected Spinoff Shares: <strong>@(_taxCalculationService.HasCurrentResult ? _expectedSpinoffQuantity.ToString("F4") : "Calculation pending")</strong>
+                Expected Spinoff Shares: <strong>@(_taxCalculationService.HasCurrentResult && _expectedSpinoffQuantity.HasValue ? _expectedSpinoffQuantity.Value.ToString("F4") : "Calculation pending")</strong>
             </DestinationInfo>
         </CorporateActionHeader>
 
@@ -132,7 +134,7 @@
     private decimal _cashFx = 1m;
     private bool _electSmallCash = true;
 
-    private decimal _expectedSpinoffQuantity;
+    private decimal? _expectedSpinoffQuantity;
     private decimal _parentRetainedPct;
     private bool _isEditing => ActionToEdit != null;
     private SpinoffCorporateAction? _previousActionToEdit;
@@ -222,14 +224,16 @@
 
     private void CalculateStats()
     {
-        _expectedSpinoffQuantity = 0;
-        if (_parentSharesRatio > 0 && !string.IsNullOrEmpty(_parentTicker))
-        {
-            decimal currentHolding = _ukSection104Pools.GetExistingOrNull(_parentTicker!)?.GetLastSection104History(DateOnly.FromDateTime(_date))?.NewQuantity ?? 0;
+        _expectedSpinoffQuantity = null;
+        if (_parentSharesRatio <= 0 || string.IsNullOrEmpty(_parentTicker)) return;
 
-            decimal rawQuantity = currentHolding * (_spinoffSharesRatio / _parentSharesRatio);
-            _expectedSpinoffQuantity = Math.Round(rawQuantity, 4, MidpointRounding.ToZero);
-        }
+        // A spinoff leaves the parent quantity alone, so the two bases agree here. Routed through the same helper
+        // anyway so every corporate action form previews the same way.
+        decimal? currentHolding = HoldingPreview.GetQuantity(_ukSection104Pools, _parentTicker, _date, ActionToEdit);
+        if (currentHolding is null) return;
+
+        decimal rawQuantity = currentHolding.Value * (_spinoffSharesRatio / _parentSharesRatio);
+        _expectedSpinoffQuantity = Math.Round(rawQuantity, 4, MidpointRounding.ToZero);
     }
 
     private void CalculateCostSplit()

--- a/BlazorApp-Investment Tax Calculator/Components/StockSplit.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/StockSplit.razor
@@ -2,6 +2,7 @@
 @using InvestmentTaxCalculator.Model.TaxEvents
 @using InvestmentTaxCalculator.Model.UkTaxModel
 @using InvestmentTaxCalculator.Services
+@using InvestmentTaxCalculator.ViewModel
 @using InvestmentTaxCalculator.Model.Interfaces
 @using InvestmentTaxCalculator.Enumerations
 @using StockSplitAction = InvestmentTaxCalculator.Model.TaxEvents.StockSplit
@@ -25,6 +26,7 @@
                                @bind-SourceRatio="@_splitFrom"
                                @bind-DestinationRatio="@_splitTo"
                                OnInputsChanged="CalculateStats"
+                               ActionToEdit="@ActionToEdit"
                                SourceLabel="Asset undergoing split"
                                DestinationLabel="N/A (Ticker remains same)"
                                RatioLabel="Split Ratio (Example: 2 for 1)"
@@ -35,7 +37,7 @@
                                RatioMin="1m"
                                IsDestinationDisabled="true">
             <DestinationInfo>
-                Expected New Quantity: <strong>@(_taxCalculationService.HasCurrentResult ? _expectedNewQuantity.ToString("F4") : "Calculation pending")</strong>
+                Expected New Quantity: <strong>@(_taxCalculationService.HasCurrentResult && _expectedNewQuantity.HasValue ? _expectedNewQuantity.Value.ToString("F4") : "Calculation pending")</strong>
             </DestinationInfo>
         </CorporateActionHeader>
 
@@ -57,7 +59,7 @@
                              CssBackgroundColor="#374151">
                 <ChildContent>
                     <div class="alert @(_fractionalRemoved > FractionalTolerance ? "alert-info" : "alert-warning") py-2 mb-0">
-                        Fractional Shares Removed: <strong>@_fractionalRemoved.ToString("F6")</strong>
+                        Fractional Shares Removed: <strong>@(_fractionalRemoved?.ToString("F6") ?? "Calculation pending")</strong>
                         @if (_fractionalRemoved <= FractionalTolerance)
                         {
                             <div class="mt-1">No fractional shares are produced by the current holding and split ratio, so cash-in-lieu cannot be applied.</div>
@@ -90,8 +92,8 @@
     private decimal _cashFx = 1m;
     private bool _electSmallCash = true;
 
-    private decimal _expectedNewQuantity;
-    private decimal _fractionalRemoved;
+    private decimal? _expectedNewQuantity;
+    private decimal? _fractionalRemoved;
     private bool _isEditing => ActionToEdit != null;
     private StockSplitAction? _previousActionToEdit;
     private const decimal FractionalTolerance = 0.00000001m;
@@ -156,15 +158,18 @@
 
     private void CalculateStats()
     {
-        _expectedNewQuantity = 0;
-        _fractionalRemoved = 0;
-        if (_splitFrom > 0 && !string.IsNullOrEmpty(_ticker))
-        {
-            decimal currentHolding = _ukSection104Pools.GetExistingOrNull(_ticker!)?.GetLastSection104History(DateOnly.FromDateTime(_date))?.NewQuantity ?? 0;
-            decimal rawNewQuantity = currentHolding * (_splitTo / _splitFrom);
-            _expectedNewQuantity = rawNewQuantity;
-            _fractionalRemoved = rawNewQuantity - Math.Floor(rawNewQuantity);
-        }
+        _expectedNewQuantity = null;
+        _fractionalRemoved = null;
+        if (_splitFrom <= 0 || string.IsNullOrEmpty(_ticker)) return;
+
+        // Editing previews against the holding before this split, otherwise the ratio is applied to a pool the
+        // split has already multiplied and the expected quantity comes out doubled.
+        decimal? currentHolding = HoldingPreview.GetQuantity(_ukSection104Pools, _ticker, _date, ActionToEdit);
+        if (currentHolding is null) return;
+
+        decimal rawNewQuantity = currentHolding.Value * (_splitTo / _splitFrom);
+        _expectedNewQuantity = rawNewQuantity;
+        _fractionalRemoved = rawNewQuantity - Math.Floor(rawNewQuantity);
     }
 
     private async Task Submit()
@@ -193,7 +198,7 @@
         CalculateStats();
 
         DescribedMoney? cashInLieu = null;
-        if (_hasCash && !_taxCalculationService.HasCurrentResult)
+        if (_hasCash && (!_taxCalculationService.HasCurrentResult || _fractionalRemoved is null))
         {
             // Whether a fraction is produced depends on the holding, which only exists after a calculation.
             _toastService.ShowError("Run the calculation so the holding is up to date before recording cash-in-lieu.");

--- a/BlazorApp-Investment Tax Calculator/Components/Takeover.razor
+++ b/BlazorApp-Investment Tax Calculator/Components/Takeover.razor
@@ -2,6 +2,7 @@
 @using InvestmentTaxCalculator.Model.TaxEvents
 @using InvestmentTaxCalculator.Model.UkTaxModel
 @using InvestmentTaxCalculator.Services
+@using InvestmentTaxCalculator.ViewModel
 @using InvestmentTaxCalculator.Model.Interfaces
 @using InvestmentTaxCalculator.Enumerations
 
@@ -37,13 +38,14 @@
                                @bind-SourceRatio="@_oldSharesRatio"
                                @bind-DestinationRatio="@_newSharesRatio"
                                OnInputsChanged="CalculateStats"
+                               ActionToEdit="@ActionToEdit"
                                SourceLabel="Original Asset (Old Company)"
                                DestinationLabel="New Company Ticker"
                                RatioLabel="Exchange Ratio (Old : New)"
                                SourceUnitLabel="shares of old company"
                                DestinationUnitLabel="shares of new company">
             <DestinationInfo>
-                Expected New Shares: <strong>@(_taxCalculationService.HasCurrentResult ? _expectedNewQuantity.ToString("F4") : "Calculation pending")</strong>
+                Expected New Shares: <strong>@(_taxCalculationService.HasCurrentResult && _expectedNewQuantity.HasValue ? _expectedNewQuantity.Value.ToString("F4") : "Calculation pending")</strong>
             </DestinationInfo>
         </CorporateActionHeader>
 
@@ -106,7 +108,7 @@
     private string _newShareMvCurrency = "GBP";
     private decimal _newShareMvFx = 1m;
 
-    private decimal _expectedNewQuantity;
+    private decimal? _expectedNewQuantity;
     private bool _isEditing => ActionToEdit != null;
     private TakeoverCorporateAction? _previousActionToEdit;
 
@@ -183,12 +185,13 @@
 
     private void CalculateStats()
     {
-        _expectedNewQuantity = 0;
-        if (_oldSharesRatio > 0 && !string.IsNullOrEmpty(_oldTicker))
-        {
-            decimal currentHolding = _ukSection104Pools.GetExistingOrNull(_oldTicker!)?.GetLastSection104History(DateOnly.FromDateTime(_date))?.NewQuantity ?? 0;
-            _expectedNewQuantity = currentHolding * (_newSharesRatio / _oldSharesRatio);
-        }
+        _expectedNewQuantity = null;
+        if (_oldSharesRatio <= 0 || string.IsNullOrEmpty(_oldTicker)) return;
+
+        // Editing previews against the holding before this takeover, otherwise it reads the pool the takeover
+        // already emptied and the expected new shares come out as zero.
+        decimal? currentHolding = HoldingPreview.GetQuantity(_ukSection104Pools, _oldTicker, _date, ActionToEdit);
+        _expectedNewQuantity = currentHolding * (_newSharesRatio / _oldSharesRatio);
     }
 
     private async Task Submit()

--- a/BlazorApp-Investment Tax Calculator/InvestmentTaxCalculator.csproj
+++ b/BlazorApp-Investment Tax Calculator/InvestmentTaxCalculator.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
 	<PublishTrimmed>true</PublishTrimmed>
 	<BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <Version>1.4.3</Version>
+    <Version>1.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/Section104History.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/Section104History.cs
@@ -9,6 +9,14 @@ namespace InvestmentTaxCalculator.Model.UkTaxModel;
 public class Section104History : ITextFilePrintable
 {
     public ITradeTaxCalculation? TradeTaxCalculation { get; set; }
+
+    /// <summary>
+    /// The corporate action whose <see cref="Interfaces.IChangeSection104.ChangeSection104"/> produced this entry,
+    /// when one did. Stamped centrally as the action is processed, so an entry form editing that action can find
+    /// the pool state that preceded it rather than reading a pool the action has already been applied to.
+    /// </summary>
+    public TaxEvents.CorporateAction? SourceCorporateAction { get; set; }
+
     public DateTime Date { get; set; }
     public decimal OldQuantity { get; set; }
     public WrappedMoney OldValue { get; set; } = WrappedMoney.GetBaseCurrencyZero();

--- a/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/UkMatchingRules.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/UkMatchingRules.cs
@@ -92,7 +92,20 @@ public static class UkMatchingRules
                         }
                         break;
                     case IChangeSection104 action:
+                        // Stamped here rather than inside each ChangeSection104 implementation: this is the single
+                        // place every one of them is invoked, so nothing has to thread the action through
+                        // MultiplyQuantity, AddAssets, ClearSection104 and the rest. Actions that touch the pool
+                        // more than once (a takeover clearing it and adding a cash disposal, a split multiplying
+                        // and then removing a fraction) get every entry they produced tagged.
+                        int stampFrom = section104.Section104HistoryList.Count;
                         action.ChangeSection104(section104);
+                        if (action is CorporateAction sourceCorporateAction)
+                        {
+                            for (int index = stampFrom; index < section104.Section104HistoryList.Count; index++)
+                            {
+                                section104.Section104HistoryList[index].SourceCorporateAction = sourceCorporateAction;
+                            }
+                        }
                         break;
                     case CorporateAction:
                         // Intentionally ignore as CorporateActions without IChangeSection104 don't need processing

--- a/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/UkSection104.cs
+++ b/BlazorApp-Investment Tax Calculator/Model/UkTaxModel/UkSection104.cs
@@ -217,6 +217,24 @@ public record UkSection104
     }
 
     /// <summary>
+    /// Quantity in the pool immediately before <paramref name="corporateAction"/> was applied, or null when the
+    /// action moved nothing here (its ticker had an empty pool, or it never touched this pool at all).
+    /// <para>
+    /// This is what an entry form editing that action needs. Reading the pool at the action's date instead returns
+    /// the holding with the action already applied, which previews a split as if it happened twice and a takeover
+    /// as a holding of zero. The value comes from the action's own first entry, so it reflects the pool at the
+    /// exact point the action ran: trades on the same date that the matching rules ordered after the action are
+    /// correctly excluded, and any ordered before it are correctly included.
+    /// </para>
+    /// </summary>
+    public decimal? GetQuantityBefore(TaxEvents.CorporateAction corporateAction)
+    {
+        return Section104HistoryList
+            .FirstOrDefault(history => ReferenceEquals(history.SourceCorporateAction, corporateAction))
+            ?.OldQuantity;
+    }
+
+    /// <summary>
     /// Used in corporate actions like stock split to multiply the quantity in the S104 pool
     /// </summary>
     /// <param name="factor"></param>

--- a/BlazorApp-Investment Tax Calculator/ViewModel/HoldingPreview.cs
+++ b/BlazorApp-Investment Tax Calculator/ViewModel/HoldingPreview.cs
@@ -1,0 +1,49 @@
+using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Model.UkTaxModel;
+
+namespace InvestmentTaxCalculator.ViewModel;
+
+/// <summary>
+/// The holding an entry form previews a corporate action against.
+/// <para>
+/// Recording a new action is straightforward: the pool on the chosen date is the basis. Editing an existing one is
+/// not, because the pools already have that action applied to them - previewing a stock split against them applies
+/// the ratio twice, and a takeover reads as a holding of zero because it emptied the pool. In that case the basis is
+/// the quantity recorded immediately before the action ran.
+/// </para>
+/// </summary>
+public static class HoldingPreview
+{
+    /// <summary>
+    /// Units to preview against, or null when there is no basis to show and the caller should say so rather than
+    /// display a number. That happens when an action being edited has been moved to a different date: where it
+    /// would then sort among that date's trades is only settled by a calculation, so no answer is available yet.
+    /// </summary>
+    /// <param name="section104Pools">The pools as they stand after the last calculation.</param>
+    /// <param name="assetName">Ticker whose holding is being previewed.</param>
+    /// <param name="date">Date currently entered on the form.</param>
+    /// <param name="actionBeingEdited">The action the form is editing, or null when recording a new one.</param>
+    public static decimal? GetQuantity(UkSection104Pools section104Pools, string? assetName, DateTime date, CorporateAction? actionBeingEdited)
+    {
+        if (string.IsNullOrWhiteSpace(assetName)) return 0m;
+
+        // GetExistingOrNull rather than GetExistingOrInitialise: tickers are selectable before a calculation has
+        // run, so a lookup must not leave an empty pool behind for one that has no pool yet.
+        UkSection104? section104 = section104Pools.GetExistingOrNull(assetName);
+        if (section104 is null) return 0m;
+
+        if (actionBeingEdited is null)
+        {
+            return section104.GetLastSection104History(DateOnly.FromDateTime(date))?.NewQuantity ?? 0m;
+        }
+
+        if (DateOnly.FromDateTime(date) != DateOnly.FromDateTime(actionBeingEdited.Date))
+        {
+            return null;
+        }
+
+        // Null here means the action moved nothing in this pool, which is a holding of zero as far as the form is
+        // concerned - distinct from the moved-date case above, where no answer exists yet.
+        return section104.GetQuantityBefore(actionBeingEdited) ?? 0m;
+    }
+}

--- a/UnitTest/Test/TradeCalculations/Stocks/UkSection104QuantityBeforeActionTest.cs
+++ b/UnitTest/Test/TradeCalculations/Stocks/UkSection104QuantityBeforeActionTest.cs
@@ -1,0 +1,189 @@
+using InvestmentTaxCalculator.Enumerations;
+using InvestmentTaxCalculator.Model;
+using InvestmentTaxCalculator.Model.TaxEvents;
+using InvestmentTaxCalculator.Model.UkTaxModel;
+using InvestmentTaxCalculator.ViewModel;
+
+using System.Globalization;
+
+using UnitTest.Helper;
+
+namespace UnitTest.Test.TradeCalculations.Stocks;
+
+/// <summary>
+/// An entry form editing a corporate action reads Section 104 pools that already have that action applied to them,
+/// which previews a split as if it happened twice and a takeover as a holding of zero. The pool records the state
+/// immediately before each movement, so the action's own entry carries the basis the form needs.
+/// </summary>
+public class UkSection104QuantityBeforeActionTest
+{
+    private const string AssetName = "SHARE";
+
+    private static Trade CreateTrade(TradeType tradeType, string date, decimal quantity, string assetName = AssetName) => new()
+    {
+        AssetName = assetName,
+        AcquisitionDisposal = tradeType,
+        Date = DateTime.Parse(date, CultureInfo.InvariantCulture),
+        Quantity = quantity,
+        GrossProceed = new() { Amount = new(quantity * 10m) },
+    };
+
+    private static UkSection104Pools BuildPools(IEnumerable<TaxEvent> taxEvents)
+    {
+        TradeCalculationHelper.CalculateTrades(taxEvents, out UkSection104Pools section104Pools);
+        return section104Pools;
+    }
+
+    [Fact]
+    public void TestStockSplitReportsTheHoldingBeforeItRatherThanTheMultipliedPool()
+    {
+        StockSplit split = new()
+        {
+            AssetName = AssetName,
+            Date = DateTime.Parse("01-Jun-23 00:00:00", CultureInfo.InvariantCulture),
+            SplitTo = 2,
+            SplitFrom = 1
+        };
+        UkSection104Pools pools = BuildPools([CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000), split]);
+        UkSection104 pool = pools.GetExistingOrInitialise(AssetName);
+
+        // What the form used to read: the pool on the split's own date, with the split already applied.
+        pool.GetLastSection104History(new DateOnly(2023, 6, 1))!.NewQuantity.ShouldBe(2000m);
+        // What it needs: 1000 before, 2000 after, rather than previewing 2000 -> 4000.
+        pool.GetQuantityBefore(split).ShouldBe(1000m);
+    }
+
+    [Fact]
+    public void TestSameDayTradeOrderedAfterTheActionIsNotPartOfItsBasis()
+    {
+        // The preview is "what you held going into the split". A purchase the matching rules order after the split
+        // was never split, so it must not appear in the basis - even though it shares the split's date.
+        StockSplit split = new()
+        {
+            AssetName = AssetName,
+            Date = DateTime.Parse("01-Jun-23 00:00:00", CultureInfo.InvariantCulture),
+            SplitTo = 2,
+            SplitFrom = 1
+        };
+        Trade sameDayPurchase = CreateTrade(TradeType.ACQUISITION, "01-Jun-23 14:00:00", 100);
+        UkSection104Pools pools = BuildPools([CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000), split, sameDayPurchase]);
+        UkSection104 pool = pools.GetExistingOrInitialise(AssetName);
+
+        pool.GetQuantityBefore(split).ShouldBe(1000m);
+        // The end of day figure does include it, which is why the basis cannot be read from there.
+        pool.GetLastSection104History(new DateOnly(2023, 6, 1))!.NewQuantity.ShouldBe(2100m);
+    }
+
+    [Fact]
+    public void TestTakeoverReportsTheHoldingBeforeItRatherThanTheEmptiedPool()
+    {
+        TakeoverCorporateAction takeover = new()
+        {
+            AssetName = "OLDCO",
+            Date = DateTime.Parse("01-Jun-23 00:00:00", CultureInfo.InvariantCulture),
+            AcquiringCompanyTicker = "NEWCO",
+            OldToNewRatio = 0.5m
+        };
+        UkSection104Pools pools = BuildPools([CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000, "OLDCO"), takeover]);
+        UkSection104 pool = pools.GetExistingOrInitialise("OLDCO");
+
+        // The takeover clears the pool, so reading its own date gives zero expected new shares.
+        pool.GetLastSection104History(new DateOnly(2023, 6, 1))!.NewQuantity.ShouldBe(0m);
+        pool.GetQuantityBefore(takeover).ShouldBe(1000m);
+    }
+
+    [Fact]
+    public void TestGiftToPartnerReportsTheHoldingBeforeTheGiftWasDeducted()
+    {
+        PartnerTransferCorporateAction gift = new()
+        {
+            AssetName = AssetName,
+            Date = DateTime.Parse("01-Jun-23 00:00:00", CultureInfo.InvariantCulture),
+            Direction = PartnerTransferDirection.GiftToPartner,
+            Quantity = 300
+        };
+        UkSection104Pools pools = BuildPools([CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000), gift]);
+        UkSection104 pool = pools.GetExistingOrInitialise(AssetName);
+
+        // Validating an increased gift against 700 is what rejected raising a 300 gift to 800.
+        pool.GetLastSection104History(new DateOnly(2023, 6, 1))!.NewQuantity.ShouldBe(700m);
+        pool.GetQuantityBefore(gift).ShouldBe(1000m);
+    }
+
+    [Fact]
+    public void TestAnActionThatMovedNothingHasNoRecordedBasis()
+    {
+        // The split returns early on an empty pool, so nothing is stamped and there is no basis to report.
+        StockSplit splitOnEmptyPool = new()
+        {
+            AssetName = AssetName,
+            Date = DateTime.Parse("01-Jan-22 00:00:00", CultureInfo.InvariantCulture),
+            SplitTo = 2,
+            SplitFrom = 1
+        };
+        UkSection104Pools pools = BuildPools([splitOnEmptyPool, CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000)]);
+
+        pools.GetExistingOrInitialise(AssetName).GetQuantityBefore(splitOnEmptyPool).ShouldBeNull();
+    }
+
+    [Fact]
+    public void TestAnActionIsOnlyABasisForThePoolItMoved()
+    {
+        // A takeover stamps entries on both the old and the acquiring pool; each one answers for itself.
+        TakeoverCorporateAction takeover = new()
+        {
+            AssetName = "OLDCO",
+            Date = DateTime.Parse("01-Jun-23 00:00:00", CultureInfo.InvariantCulture),
+            AcquiringCompanyTicker = "NEWCO",
+            OldToNewRatio = 0.5m
+        };
+        UkSection104Pools pools = BuildPools([CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000, "OLDCO"), takeover]);
+
+        pools.GetExistingOrInitialise("OLDCO").GetQuantityBefore(takeover).ShouldBe(1000m);
+        // The acquiring pool held nothing before the takeover filled it.
+        pools.GetExistingOrInitialise("NEWCO").GetQuantityBefore(takeover).ShouldBe(0m);
+    }
+
+    [Fact]
+    public void TestPreviewUsesThePoolWhenRecordingAndThePriorStateWhenEditing()
+    {
+        StockSplit split = new()
+        {
+            AssetName = AssetName,
+            Date = DateTime.Parse("01-Jun-23 00:00:00", CultureInfo.InvariantCulture),
+            SplitTo = 2,
+            SplitFrom = 1
+        };
+        UkSection104Pools pools = BuildPools([CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000), split]);
+        DateTime splitDate = DateTime.Parse("01-Jun-23 00:00:00", CultureInfo.InvariantCulture);
+
+        HoldingPreview.GetQuantity(pools, AssetName, splitDate, actionBeingEdited: null).ShouldBe(2000m);
+        HoldingPreview.GetQuantity(pools, AssetName, splitDate, split).ShouldBe(1000m);
+    }
+
+    [Fact]
+    public void TestPreviewHasNoAnswerWhenAnActionBeingEditedIsMovedToAnotherDate()
+    {
+        // Where the action would sort among the new date's trades is only settled by a calculation, so the form is
+        // told there is nothing to show rather than being handed the basis from the old date.
+        StockSplit split = new()
+        {
+            AssetName = AssetName,
+            Date = DateTime.Parse("01-Jun-23 00:00:00", CultureInfo.InvariantCulture),
+            SplitTo = 2,
+            SplitFrom = 1
+        };
+        UkSection104Pools pools = BuildPools([CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000), split]);
+
+        HoldingPreview.GetQuantity(pools, AssetName, DateTime.Parse("01-Jul-23 00:00:00", CultureInfo.InvariantCulture), split).ShouldBeNull();
+    }
+
+    [Fact]
+    public void TestPreviewReportsZeroForATickerWithNoPool()
+    {
+        UkSection104Pools pools = BuildPools([CreateTrade(TradeType.ACQUISITION, "01-Jan-23 10:00:00", 1000)]);
+
+        HoldingPreview.GetQuantity(pools, "NOT_IMPORTED", DateTime.Parse("01-Jun-23 00:00:00", CultureInfo.InvariantCulture), null).ShouldBe(0m);
+        HoldingPreview.GetQuantity(pools, assetName: null, DateTime.Parse("01-Jun-23 00:00:00", CultureInfo.InvariantCulture), null).ShouldBe(0m);
+    }
+}


### PR DESCRIPTION
Fixes the edit-time holdings issue raised in #263 ([r3873735930](https://github.com/alexpung/UK-Investment-tax-calculator/pull/263#discussion_r3873735930)).

> **Stacked on #263.** Base is `claude/eri-corporate-actions-prepopulate-cj58pn`, not `master`, because this touches the same four entry forms. Merge #263 first, then this rebases onto master cleanly.

## The problem

Editing a corporate action reads Section 104 pools that **already have that action applied**, because the form queries the pool at the action's own date and the lookup is `<=`.

| Form | Effect on its own pool entry | What the edit screen showed |
|---|---|---|
| Stock split | `MultiplyQuantity` | Ratio applied twice — 1000 previews as 2000 → 4000 |
| Takeover | `ClearSection104` | Reads the pool it emptied: "Expected New Shares: 0.0000" |
| Gift to partner | `AddAssets(Date, −Quantity, …)` | Gift of 300 from 1000 validated against 700, so **raising it to 800 was rejected** |
| Spinoff | `AdjustAcquisitionCost` only | Not affected — a spinoff leaves the parent quantity alone |

**Nothing incorrect was ever saved.** These forms persist user-typed ratios and quantities, never the previewed figure, so no wrong number reached the calculation. The gift guard is the only one that blocked rather than merely misled, and it errs strict — it rejected valid edits, it never let an over-gift through.

## The fix

The pool already records what's needed: every entry carries `OldQuantity`, the state immediately before that movement. So the action's own first entry *is* the basis. What was missing was any link from an entry back to the action that produced it:

- **`Section104History.SourceCorporateAction`** — new nullable field.
- **`UkMatchingRules`** stamps it around the *single* call site of `ChangeSection104` (`:95`). No signatures change, and actions that touch the pool more than once — a takeover clearing it and adding a cash disposal, a split multiplying then removing a fraction — get every entry tagged.
- **`UkSection104.GetQuantityBefore(action)`** returns that entry's `OldQuantity`.

## Why `OldQuantity` rather than filtering the action out of a date query

My first sketch summed quantity deltas up to the date, skipping the action's rows. That answers the wrong question. Split 1000 → 2000 on 1 Jun with a same-day purchase of 100: the delta sum gives 1100, but the preview should read **1000 → 2000**.

Reading `OldQuantity` also settles the same-day question by deferring to the order the matching rules actually used, rather than inventing a rule:

- Purchase ordered **after** the split → excluded from the basis. Correct: it was never split.
- Purchase ordered **before** the split → included. Equally correct: those shares really were split.

A blanket "ignore same-day trades" rule would get the second case wrong. `TestSameDayTradeOrderedAfterTheActionIsNotPartOfItsBasis` pins this, and confirms the calculation does order that purchase after the split (basis 1000, end-of-day 2100).

## `HoldingPreview`

A small static helper holding the choice between the two bases, so all four forms preview identically: pool-at-date when recording, pre-action state when editing.

It returns `null` — and the forms show the quantity as pending — when an action being edited is **moved to a different date**. Where it would then sort among that date's trades is only settled by a calculation, so there is no answer to give yet. That's the one case this doesn't make exact, deliberately.

While editing, the holding label reads "Holding before this action on …" and the breakdown panel is hidden, since it explains the post-action pool rather than the previewed basis.

## Testing

`dotnet build --configuration Release` clean, 0 warnings. All **376** unit tests pass (9 new in `UkSection104QuantityBeforeActionTest`), each asserting both the old misleading figure and the new basis so the difference is visible:

- split (2000 vs 1000), takeover (0 vs 1000), gift (700 vs 1000)
- same-day trade ordered after the action
- action that moved nothing → no basis recorded
- a takeover answering separately for the old and acquiring pools
- `HoldingPreview` recording vs editing, the moved-date case, and unknown tickers

Version bumped to 1.5.0. Note the repo's workflow has no `pull_request` trigger, so CI won't run on this PR either; the Playwright suite is Windows-only and was not run.

## Not included

Two adjacent problems in `CorporateActionsList`, which renders Edit and Delete for **every** corporate action — both pre-existing and out of scope here:

- Edit on an ERI, equalisation or return-of-capital row is a silent no-op (`HandleEdit` only switches on takeover/spinoff/split/partner transfer).
- Delete on an ERI row removes the corporate action but leaves the `Dividend`/`InterestIncome` that `EriControl` created alongside it, so that income stays taxable. **This one changes tax output.**

Happy to open issues or a follow-up PR for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ppZdQEikzbSbkX4AGBuSC

---
_Generated by [Claude Code](https://claude.ai/code/session_013ppZdQEikzbSbkX4AGBuSC)_